### PR TITLE
feat: add recurring task support

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -9,6 +9,7 @@ import {
   TextField,
   TextFieldProps,
   Tooltip,
+  MenuItem,
 } from "@mui/material";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { ColorPicker, CustomDialogTitle, CustomEmojiPicker } from "..";
@@ -67,7 +68,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
     // Update the editedTask state with the changed value.
     setEditedTask((prevTask) => ({
       ...(prevTask as Task),
-      [name]: value,
+      [name]: name === "recurrence" && value === "none" ? undefined : value,
     }));
   };
   // Event handler for saving the edited task.
@@ -83,6 +84,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             emoji: editedTask.emoji || undefined,
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
+            recurrence: editedTask.recurrence || undefined,
             category: editedTask.category || undefined,
             lastSave: new Date(),
           };
@@ -241,6 +243,19 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
+
+        <StyledInput
+          select
+          label="Recurrence"
+          name="recurrence"
+          value={editedTask?.recurrence || "none"}
+          onChange={handleInputChange}
+        >
+          <MenuItem value="none">None</MenuItem>
+          <MenuItem value="daily">Daily</MenuItem>
+          <MenuItem value="weekly">Weekly</MenuItem>
+          <MenuItem value="monthly">Monthly</MenuItem>
+        </StyledInput>
 
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -27,7 +27,7 @@ import { TaskIcon, TaskItem } from "..";
 import { UserContext } from "../../contexts/UserContext";
 import { useResponsiveDisplay } from "../../hooks/useResponsiveDisplay";
 import { Task } from "../../types/user";
-import { calculateDateDifference, generateUUID, showToast } from "../../utils";
+import { calculateDateDifference, generateUUID, showToast, getNextOccurrence } from "../../utils";
 import { useTheme } from "@emotion/react";
 import { TaskContext } from "../../contexts/TaskContext";
 import { ColorPalette } from "../../theme/themeConfig";
@@ -70,18 +70,23 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
+      const originalTask = tasks.find((t) => t.id === selectedTaskId);
       const updatedTasks = tasks.map((task) => {
         if (task.id === selectedTaskId) {
           return { ...task, done: !task.done, lastSave: new Date() };
         }
         return task;
       });
+      let finalTasks = updatedTasks;
+      if (originalTask && !originalTask.done && originalTask.recurrence) {
+        finalTasks = [...updatedTasks, getNextOccurrence(originalTask)];
+      }
       setUser((prevUser) => ({
         ...prevUser,
-        tasks: updatedTasks,
+        tasks: finalTasks,
       }));
 
-      const allTasksDone = updatedTasks.every((task) => task.done);
+      const allTasksDone = finalTasks.every((task) => task.done);
 
       if (allTasksDone) {
         showToast(

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -29,7 +29,7 @@ import { useStorageState } from "../../hooks/useStorageState";
 import { DialogBtn } from "../../styles";
 import { ColorPalette } from "../../theme/themeConfig";
 import type { Category, Task, UUID } from "../../types/user";
-import { getFontColor, showToast } from "../../utils";
+import { getFontColor, showToast, getNextOccurrence } from "../../utils";
 import {
   NoTasks,
   RingAlarm,
@@ -267,16 +267,18 @@ export const TasksList: React.FC = () => {
   };
 
   const handleMarkSelectedAsDone = () => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      tasks: prevUser.tasks.map((task) => {
+    setUser((prevUser) => {
+      const updatedTasks = prevUser.tasks.map((task) => {
         if (multipleSelectedTasks.includes(task.id)) {
-          // Mark the task as done if selected
           return { ...task, done: true, lastSave: new Date() };
         }
         return task;
-      }),
-    }));
+      });
+      const nextTasks = prevUser.tasks
+        .filter((task) => multipleSelectedTasks.includes(task.id) && !task.done && task.recurrence)
+        .map((task) => getNextOccurrence(task));
+      return { ...prevUser, tasks: [...updatedTasks, ...nextTasks] };
+    });
     // Clear the selected task IDs after the operation
     setMultipleSelectedTasks([]);
   };

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -1,9 +1,9 @@
-import { Category, Task } from "../types/user";
+import { Category, Task, Recurrence } from "../types/user";
 import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
 import { AddTaskRounded, CancelRounded } from "@mui/icons-material";
-import { IconButton, InputAdornment, Tooltip } from "@mui/material";
+import { IconButton, InputAdornment, Tooltip, MenuItem } from "@mui/material";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../constants";
 import { ColorPicker, TopBar, CustomEmojiPicker } from "../components";
 import { UserContext } from "../contexts/UserContext";
@@ -27,6 +27,11 @@ const AddTask = () => {
     "sessionStorage",
   );
   const [deadline, setDeadline] = useStorageState<string>("", "deadline", "sessionStorage");
+  const [recurrence, setRecurrence] = useStorageState<"none" | Recurrence>(
+    "none",
+    "recurrence",
+    "sessionStorage",
+  );
   const [nameError, setNameError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
@@ -85,6 +90,10 @@ const AddTask = () => {
     setDeadline(event.target.value);
   };
 
+  const handleRecurrenceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRecurrence(event.target.value as "none" | Recurrence);
+  };
+
   const handleAddTask = () => {
     if (name === "") {
       showToast("Task name is required.", {
@@ -110,6 +119,7 @@ const AddTask = () => {
       color,
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
+      recurrence: recurrence !== "none" ? (recurrence as Recurrence) : undefined,
       category: selectedCategories ? selectedCategories : [],
     };
 
@@ -129,7 +139,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -211,6 +229,18 @@ const AddTask = () => {
               },
             }}
           />
+
+          <StyledInput
+            select
+            label="Recurrence"
+            value={recurrence}
+            onChange={handleRecurrenceChange}
+          >
+            <MenuItem value="none">None</MenuItem>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </StyledInput>
 
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -7,6 +7,8 @@ export type UUID = ReturnType<typeof crypto.randomUUID>;
 
 export type DarkModeOptions = "system" | "auto" | "light" | "dark";
 
+export type Recurrence = "daily" | "weekly" | "monthly";
+
 /**
  * Represents a user in the application.
  */
@@ -50,6 +52,7 @@ export interface Task {
    */
   date: Date;
   deadline?: Date;
+  recurrence?: Recurrence;
   category?: Category[];
   lastSave?: Date;
   sharedBy?: string;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -52,6 +52,10 @@ export interface Task {
    */
   date: Date;
   deadline?: Date;
+  /**
+   * Optional recurrence interval; existing tasks without this field remain valid,
+   * ensuring backward compatibility.
+   */
   recurrence?: Recurrence;
   category?: Category[];
   lastSave?: Date;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,7 @@ export { saveQRCode } from "./saveQRCode";
 export { showToast } from "./showToast";
 export { generateUUID } from "./generateUUID";
 export { timeAgo, formatDate, calculateDateDifference } from "./timeUtils";
+export { getNextOccurrence } from "./recurrence";
 export {
   initDB,
   deleteProfilePictureFromDB,

--- a/src/utils/recurrence.ts
+++ b/src/utils/recurrence.ts
@@ -1,0 +1,28 @@
+import { Task } from "../types/user";
+import { generateUUID } from "./generateUUID";
+
+export const getNextOccurrence = (task: Task): Task => {
+  const nextDeadline = task.deadline ? new Date(task.deadline) : undefined;
+  if (nextDeadline) {
+    switch (task.recurrence) {
+      case "daily":
+        nextDeadline.setDate(nextDeadline.getDate() + 1);
+        break;
+      case "weekly":
+        nextDeadline.setDate(nextDeadline.getDate() + 7);
+        break;
+      case "monthly":
+        nextDeadline.setMonth(nextDeadline.getMonth() + 1);
+        break;
+    }
+  }
+
+  return {
+    ...task,
+    id: generateUUID(),
+    done: false,
+    date: new Date(),
+    deadline: nextDeadline,
+    lastSave: new Date(),
+  };
+};


### PR DESCRIPTION
## Summary
- add Recurrence type and support recurring tasks
- allow selecting recurrence when creating or editing tasks
- generate next instance automatically when recurring task is completed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898456c33a0832ba671522dafa5c7d2