### PR TITLE
Add recurring tasks (daily/weekly/monthly) with next occurrence on completion

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -9,15 +9,15 @@ import {
   TextField,
   TextFieldProps,
   Tooltip,
+  MenuItem,
 } from "@mui/material";
-import { Select, MenuItem } from "@mui/material";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { ColorPicker, CustomDialogTitle, CustomEmojiPicker } from "..";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../../constants";
 import { UserContext } from "../../contexts/UserContext";
 import { DialogBtn } from "../../styles";
-import { Category, Task } from "../../types/user";
-import { formatDate, showToast, timeAgo, getFontColor } from "../../utils";
+import { Category, Task, Recurrence } from "../../types/user";
+import { formatDate, showToast, timeAgo } from "../../utils";
 import { useTheme } from "@emotion/react";
 import { ColorPalette } from "../../theme/themeConfig";
 import { CategorySelect } from "../CategorySelect";
@@ -85,7 +85,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
             category: editedTask.category || undefined,
-            recurrence: editedTask.recurrence || undefined,
+            recurrence: editedTask.recurrence ?? 'none',
             lastSave: new Date(),
           };
         }
@@ -244,6 +244,19 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
           }}
         />
 
+        <StyledInput
+          label="Recurrence"
+          select
+          name="recurrence"
+          value={editedTask?.recurrence ?? 'none'}
+          onChange={(e) => setEditedTask((prev) => ({ ...(prev as Task), recurrence: e.target.value as Recurrence }))}
+        >
+          <MenuItem value="none">None</MenuItem>
+          <MenuItem value="daily">Daily</MenuItem>
+          <MenuItem value="weekly">Weekly</MenuItem>
+          <MenuItem value="monthly">Monthly</MenuItem>
+        </StyledInput>
+
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect
             fontColor={theme.darkmode ? ColorPalette.fontLight : ColorPalette.fontDark}
@@ -259,29 +272,6 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             marginTop: "8px",
           }}
         >
-          {/* Recurrence selector */}
-          <Select
-            fullWidth
-            value={editedTask?.recurrence ?? "none"}
-            onChange={(e) =>
-              setEditedTask((prev) => ({
-                ...(prev as Task),
-                recurrence: e.target.value === "none" ? undefined : (e.target.value as any),
-              }))
-            }
-            displayEmpty
-            sx={{
-              mb: "14px",
-              borderRadius: "16px",
-              background: theme.secondary,
-              color: getFontColor(theme.secondary),
-            }}
-          >
-            <MenuItem value="none">None</MenuItem>
-            <MenuItem value="daily">Daily</MenuItem>
-            <MenuItem value="weekly">Weekly</MenuItem>
-            <MenuItem value="monthly">Monthly</MenuItem>
-          </Select>
           <ColorPicker
             width={"100%"}
             color={editedTask?.color || "#000000"}

--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -6,18 +6,18 @@ import {
   DialogContent,
   IconButton,
   InputAdornment,
-  MenuItem,
   TextField,
   TextFieldProps,
   Tooltip,
 } from "@mui/material";
+import { Select, MenuItem } from "@mui/material";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { ColorPicker, CustomDialogTitle, CustomEmojiPicker } from "..";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../../constants";
 import { UserContext } from "../../contexts/UserContext";
 import { DialogBtn } from "../../styles";
 import { Category, Task } from "../../types/user";
-import { formatDate, showToast, timeAgo } from "../../utils";
+import { formatDate, showToast, timeAgo, getFontColor } from "../../utils";
 import { useTheme } from "@emotion/react";
 import { ColorPalette } from "../../theme/themeConfig";
 import { CategorySelect } from "../CategorySelect";
@@ -65,16 +65,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
 
-    // Special handling for deadline (needs to be stored as Date | undefined)
-    if (name === "deadline") {
-      setEditedTask((prevTask) => ({
-        ...(prevTask as Task),
-        deadline: value ? new Date(value) : undefined,
-      }));
-      return;
-    }
-
-    // Update the editedTask state with the changed value for other fields
+    // Update the editedTask state with the changed value.
     setEditedTask((prevTask) => ({
       ...(prevTask as Task),
       [name]: value,
@@ -253,19 +244,6 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
           }}
         />
 
-        <StyledInput
-          label="Recurrence"
-          name="recurrence"
-          select
-          value={editedTask?.recurrence || "none"}
-          onChange={handleInputChange}
-        >
-          <MenuItem value="none">None</MenuItem>
-          <MenuItem value="daily">Daily</MenuItem>
-          <MenuItem value="weekly">Weekly</MenuItem>
-          <MenuItem value="monthly">Monthly</MenuItem>
-        </StyledInput>
-
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect
             fontColor={theme.darkmode ? ColorPalette.fontLight : ColorPalette.fontDark}
@@ -281,6 +259,29 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             marginTop: "8px",
           }}
         >
+          {/* Recurrence selector */}
+          <Select
+            fullWidth
+            value={editedTask?.recurrence ?? "none"}
+            onChange={(e) =>
+              setEditedTask((prev) => ({
+                ...(prev as Task),
+                recurrence: e.target.value === "none" ? undefined : (e.target.value as any),
+              }))
+            }
+            displayEmpty
+            sx={{
+              mb: "14px",
+              borderRadius: "16px",
+              background: theme.secondary,
+              color: getFontColor(theme.secondary),
+            }}
+          >
+            <MenuItem value="none">None</MenuItem>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </Select>
           <ColorPicker
             width={"100%"}
             color={editedTask?.color || "#000000"}

--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -6,6 +6,7 @@ import {
   DialogContent,
   IconButton,
   InputAdornment,
+  MenuItem,
   TextField,
   TextFieldProps,
   Tooltip,
@@ -64,7 +65,16 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
 
-    // Update the editedTask state with the changed value.
+    // Special handling for deadline (needs to be stored as Date | undefined)
+    if (name === "deadline") {
+      setEditedTask((prevTask) => ({
+        ...(prevTask as Task),
+        deadline: value ? new Date(value) : undefined,
+      }));
+      return;
+    }
+
+    // Update the editedTask state with the changed value for other fields
     setEditedTask((prevTask) => ({
       ...(prevTask as Task),
       [name]: value,
@@ -84,6 +94,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
             category: editedTask.category || undefined,
+            recurrence: editedTask.recurrence || undefined,
             lastSave: new Date(),
           };
         }
@@ -241,6 +252,19 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
+
+        <StyledInput
+          label="Recurrence"
+          name="recurrence"
+          select
+          value={editedTask?.recurrence || "none"}
+          onChange={handleInputChange}
+        >
+          <MenuItem value="none">None</MenuItem>
+          <MenuItem value="daily">Daily</MenuItem>
+          <MenuItem value="weekly">Weekly</MenuItem>
+          <MenuItem value="monthly">Monthly</MenuItem>
+        </StyledInput>
 
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -30,8 +30,8 @@ import { Task } from "../../types/user";
 import {
   calculateDateDifference,
   generateUUID,
-  getNextOccurrenceDate,
   showToast,
+  addInterval,
 } from "../../utils";
 import { useTheme } from "@emotion/react";
 import { TaskContext } from "../../contexts/TaskContext";
@@ -75,40 +75,35 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
-      const newOccurrences: Task[] = [];
-      const updatedTasks = tasks.map((task) => {
+      const updatedTasks: Task[] = tasks.map((task) => {
         if (task.id === selectedTaskId) {
-          const toggledTask = { ...task, done: !task.done, lastSave: new Date() };
-
-          // If we just marked the task as done and it is recurring with a deadline,
-          // create the next occurrence immediately.
-          if (
-            !task.done && // it was previously not done (now becoming done)
-            task.recurrence &&
-            task.deadline
-          ) {
-            const nextDeadline = getNextOccurrenceDate(
-              new Date(task.deadline),
-              task.recurrence,
-            );
-            const nextTask: Task = {
-              ...task,
-              id: generateUUID(),
-              done: false,
-              date: new Date(),
-              deadline: nextDeadline,
-              lastSave: undefined,
-            };
-            newOccurrences.push(nextTask);
-          }
-
-          return toggledTask;
+          return { ...task, done: !task.done, lastSave: new Date() };
         }
         return task;
       });
+
+      // If the task is being marked as done *now* and it is recurring, create next occurrence
+      if (!selectedTask.done && selectedTask.recurrence) {
+        const nextDeadline =
+          selectedTask.deadline !== undefined
+            ? addInterval(new Date(selectedTask.deadline), selectedTask.recurrence)
+            : undefined;
+
+        const nextTask: Task = {
+          ...selectedTask,
+          id: generateUUID(),
+          done: false,
+          date: new Date(),
+          deadline: nextDeadline,
+          lastSave: undefined,
+          position: undefined,
+        };
+        updatedTasks.push(nextTask);
+      }
+
       setUser((prevUser) => ({
         ...prevUser,
-        tasks: [...updatedTasks, ...newOccurrences],
+        tasks: updatedTasks,
       }));
 
       const allTasksDone = updatedTasks.every((task) => task.done);

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -27,7 +27,12 @@ import { TaskIcon, TaskItem } from "..";
 import { UserContext } from "../../contexts/UserContext";
 import { useResponsiveDisplay } from "../../hooks/useResponsiveDisplay";
 import { Task } from "../../types/user";
-import { calculateDateDifference, generateUUID, showToast } from "../../utils";
+import {
+  calculateDateDifference,
+  generateUUID,
+  getNextOccurrenceDate,
+  showToast,
+} from "../../utils";
 import { useTheme } from "@emotion/react";
 import { TaskContext } from "../../contexts/TaskContext";
 import { ColorPalette } from "../../theme/themeConfig";
@@ -70,15 +75,40 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
+      const newOccurrences: Task[] = [];
       const updatedTasks = tasks.map((task) => {
         if (task.id === selectedTaskId) {
-          return { ...task, done: !task.done, lastSave: new Date() };
+          const toggledTask = { ...task, done: !task.done, lastSave: new Date() };
+
+          // If we just marked the task as done and it is recurring with a deadline,
+          // create the next occurrence immediately.
+          if (
+            !task.done && // it was previously not done (now becoming done)
+            task.recurrence &&
+            task.deadline
+          ) {
+            const nextDeadline = getNextOccurrenceDate(
+              new Date(task.deadline),
+              task.recurrence,
+            );
+            const nextTask: Task = {
+              ...task,
+              id: generateUUID(),
+              done: false,
+              date: new Date(),
+              deadline: nextDeadline,
+              lastSave: undefined,
+            };
+            newOccurrences.push(nextTask);
+          }
+
+          return toggledTask;
         }
         return task;
       });
       setUser((prevUser) => ({
         ...prevUser,
-        tasks: updatedTasks,
+        tasks: [...updatedTasks, ...newOccurrences],
       }));
 
       const allTasksDone = updatedTasks.every((task) => task.done);

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -26,13 +26,8 @@ import "react-spring-bottom-sheet/dist/style.css";
 import { TaskIcon, TaskItem } from "..";
 import { UserContext } from "../../contexts/UserContext";
 import { useResponsiveDisplay } from "../../hooks/useResponsiveDisplay";
-import { Task } from "../../types/user";
-import {
-  calculateDateDifference,
-  generateUUID,
-  showToast,
-  addInterval,
-} from "../../utils";
+import { Task, Recurrence } from "../../types/user";
+import { calculateDateDifference, generateUUID, showToast } from "../../utils";
 import { useTheme } from "@emotion/react";
 import { TaskContext } from "../../contexts/TaskContext";
 import { ColorPalette } from "../../theme/themeConfig";
@@ -75,20 +70,38 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
-      const updatedTasks: Task[] = tasks.map((task) => {
+
+      // store previous done state to know if we are completing now
+      const wasDone = selectedTask.done;
+      let updatedTasks = tasks.map((task) => {
         if (task.id === selectedTaskId) {
           return { ...task, done: !task.done, lastSave: new Date() };
         }
         return task;
       });
 
-      // If the task is being marked as done *now* and it is recurring, create next occurrence
-      if (!selectedTask.done && selectedTask.recurrence) {
-        const nextDeadline =
-          selectedTask.deadline !== undefined
-            ? addInterval(new Date(selectedTask.deadline), selectedTask.recurrence)
-            : undefined;
-
+      // if task is getting marked as done and it is recurring, create next occurrence
+      if (
+        !wasDone &&
+        selectedTask.recurrence &&
+        selectedTask.recurrence !== "none"
+      ) {
+        let nextDeadline: Date | undefined = undefined;
+        if (selectedTask.deadline) {
+          const d = new Date(selectedTask.deadline);
+          switch (selectedTask.recurrence as Recurrence) {
+            case "daily":
+              d.setDate(d.getDate() + 1);
+              break;
+            case "weekly":
+              d.setDate(d.getDate() + 7);
+              break;
+            case "monthly":
+              d.setMonth(d.getMonth() + 1);
+              break;
+          }
+          nextDeadline = d;
+        }
         const nextTask: Task = {
           ...selectedTask,
           id: generateUUID(),
@@ -96,7 +109,6 @@ export const TaskMenu = () => {
           date: new Date(),
           deadline: nextDeadline,
           lastSave: undefined,
-          position: undefined,
         };
         updatedTasks.push(nextTask);
       }

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -29,12 +29,7 @@ import { useStorageState } from "../../hooks/useStorageState";
 import { DialogBtn } from "../../styles";
 import { ColorPalette } from "../../theme/themeConfig";
 import type { Category, Task, UUID } from "../../types/user";
-import {
-  getFontColor,
-  showToast,
-  generateUUID,
-  getNextOccurrenceDate,
-} from "../../utils";
+import { getFontColor, showToast, addInterval, generateUUID } from "../../utils";
 import {
   NoTasks,
   RingAlarm,
@@ -273,37 +268,41 @@ export const TasksList: React.FC = () => {
 
   const handleMarkSelectedAsDone = () => {
     setUser((prevUser) => {
-      const newOccurrences: Task[] = [];
-
+      // First, mark selected tasks as done
       const updatedTasks = prevUser.tasks.map((task) => {
         if (multipleSelectedTasks.includes(task.id)) {
-          // If task is being marked done now (was previously not done)
-          if (!task.done && task.recurrence && task.deadline) {
-            const nextDeadline = getNextOccurrenceDate(
-              new Date(task.deadline),
-              task.recurrence,
-            );
-
-            const nextTask: Task = {
-              ...task,
-              id: generateUUID(),
-              done: false,
-              date: new Date(),
-              deadline: nextDeadline,
-              lastSave: undefined,
-            };
-            newOccurrences.push(nextTask);
-          }
-
-          // Mark the task as done
           return { ...task, done: true, lastSave: new Date() };
         }
         return task;
       });
 
+      // Then, create next occurrences for newly-completed recurring tasks
+      const newTasks: Task[] = [];
+      prevUser.tasks.forEach((task) => {
+        if (
+          multipleSelectedTasks.includes(task.id) && // part of selection
+          !task.done && // was not already done
+          task.recurrence // has recurrence rule
+        ) {
+          const nextDeadline = task.deadline
+            ? addInterval(new Date(task.deadline), task.recurrence)
+            : undefined;
+
+          newTasks.push({
+            ...task,
+            id: generateUUID(),
+            done: false,
+            date: new Date(),
+            deadline: nextDeadline,
+            lastSave: undefined,
+            position: undefined,
+          });
+        }
+      });
+
       return {
         ...prevUser,
-        tasks: [...updatedTasks, ...newOccurrences],
+        tasks: [...updatedTasks, ...newTasks],
       };
     });
     // Clear the selected task IDs after the operation

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -29,7 +29,12 @@ import { useStorageState } from "../../hooks/useStorageState";
 import { DialogBtn } from "../../styles";
 import { ColorPalette } from "../../theme/themeConfig";
 import type { Category, Task, UUID } from "../../types/user";
-import { getFontColor, showToast } from "../../utils";
+import {
+  getFontColor,
+  showToast,
+  generateUUID,
+  getNextOccurrenceDate,
+} from "../../utils";
 import {
   NoTasks,
   RingAlarm,
@@ -267,16 +272,40 @@ export const TasksList: React.FC = () => {
   };
 
   const handleMarkSelectedAsDone = () => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      tasks: prevUser.tasks.map((task) => {
+    setUser((prevUser) => {
+      const newOccurrences: Task[] = [];
+
+      const updatedTasks = prevUser.tasks.map((task) => {
         if (multipleSelectedTasks.includes(task.id)) {
-          // Mark the task as done if selected
+          // If task is being marked done now (was previously not done)
+          if (!task.done && task.recurrence && task.deadline) {
+            const nextDeadline = getNextOccurrenceDate(
+              new Date(task.deadline),
+              task.recurrence,
+            );
+
+            const nextTask: Task = {
+              ...task,
+              id: generateUUID(),
+              done: false,
+              date: new Date(),
+              deadline: nextDeadline,
+              lastSave: undefined,
+            };
+            newOccurrences.push(nextTask);
+          }
+
+          // Mark the task as done
           return { ...task, done: true, lastSave: new Date() };
         }
         return task;
-      }),
-    }));
+      });
+
+      return {
+        ...prevUser,
+        tasks: [...updatedTasks, ...newOccurrences],
+      };
+    });
     // Clear the selected task IDs after the operation
     setMultipleSelectedTasks([]);
   };

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
 import { AddTaskRounded, CancelRounded } from "@mui/icons-material";
-import { IconButton, InputAdornment, Tooltip } from "@mui/material";
+import { IconButton, InputAdornment, Tooltip, MenuItem } from "@mui/material";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../constants";
 import { ColorPicker, TopBar, CustomEmojiPicker } from "../components";
 import { UserContext } from "../contexts/UserContext";
@@ -27,6 +27,11 @@ const AddTask = () => {
     "sessionStorage",
   );
   const [deadline, setDeadline] = useStorageState<string>("", "deadline", "sessionStorage");
+  const [recurrence, setRecurrence] = useStorageState<string>(
+    "none",
+    "recurrence",
+    "sessionStorage",
+  );
   const [nameError, setNameError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
@@ -85,6 +90,10 @@ const AddTask = () => {
     setDeadline(event.target.value);
   };
 
+  const handleRecurrenceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRecurrence(event.target.value);
+  };
+
   const handleAddTask = () => {
     if (name === "") {
       showToast("Task name is required.", {
@@ -111,6 +120,7 @@ const AddTask = () => {
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
       category: selectedCategories ? selectedCategories : [],
+      recurrence: recurrence !== "none" ? (recurrence as any) : undefined,
     };
 
     setUser((prevUser) => ({
@@ -129,7 +139,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -211,6 +229,20 @@ const AddTask = () => {
               },
             }}
           />
+
+          {/* Recurrence selector */}
+          <StyledInput
+            label="Recurrence"
+            select
+            value={recurrence}
+            onChange={handleRecurrenceChange}
+            sx={{ width: "400px" }}
+          >
+            <MenuItem value="none">None</MenuItem>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </StyledInput>
 
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
 import { AddTaskRounded, CancelRounded } from "@mui/icons-material";
-import { IconButton, InputAdornment, Tooltip, MenuItem } from "@mui/material";
+import { IconButton, InputAdornment, Tooltip, Select, MenuItem } from "@mui/material";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../constants";
 import { ColorPicker, TopBar, CustomEmojiPicker } from "../components";
 import { UserContext } from "../contexts/UserContext";
@@ -27,11 +27,6 @@ const AddTask = () => {
     "sessionStorage",
   );
   const [deadline, setDeadline] = useStorageState<string>("", "deadline", "sessionStorage");
-  const [recurrence, setRecurrence] = useStorageState<string>(
-    "none",
-    "recurrence",
-    "sessionStorage",
-  );
   const [nameError, setNameError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
@@ -39,6 +34,9 @@ const AddTask = () => {
     "categories",
     "sessionStorage",
   );
+  const [recurrence, setRecurrence] = useStorageState<
+    "none" | "daily" | "weekly" | "monthly"
+  >("none", "recurrence", "sessionStorage");
 
   const [isDeadlineFocused, setIsDeadlineFocused] = useState<boolean>(false);
 
@@ -90,10 +88,6 @@ const AddTask = () => {
     setDeadline(event.target.value);
   };
 
-  const handleRecurrenceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setRecurrence(event.target.value);
-  };
-
   const handleAddTask = () => {
     if (name === "") {
       showToast("Task name is required.", {
@@ -120,7 +114,7 @@ const AddTask = () => {
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
       category: selectedCategories ? selectedCategories : [],
-      recurrence: recurrence !== "none" ? (recurrence as any) : undefined,
+      ...(recurrence !== "none" ? { recurrence } : {}),
     };
 
     setUser((prevUser) => ({
@@ -139,15 +133,7 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = [
-      "name",
-      "color",
-      "description",
-      "emoji",
-      "deadline",
-      "categories",
-      "recurrence",
-    ];
+    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -230,20 +216,6 @@ const AddTask = () => {
             }}
           />
 
-          {/* Recurrence selector */}
-          <StyledInput
-            label="Recurrence"
-            select
-            value={recurrence}
-            onChange={handleRecurrenceChange}
-            sx={{ width: "400px" }}
-          >
-            <MenuItem value="none">None</MenuItem>
-            <MenuItem value="daily">Daily</MenuItem>
-            <MenuItem value="weekly">Weekly</MenuItem>
-            <MenuItem value="monthly">Monthly</MenuItem>
-          </StyledInput>
-
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>
               <br />
@@ -256,6 +228,29 @@ const AddTask = () => {
             </div>
           )}
         </InputThemeProvider>
+
+        {/* Recurrence selector */}
+        <InputThemeProvider>
+          <div style={{ marginBottom: "14px", width: "400px" }}>
+            <Select
+              fullWidth
+              value={recurrence}
+              onChange={(e) => setRecurrence(e.target.value as typeof recurrence)}
+              displayEmpty
+              sx={{
+                borderRadius: "16px",
+                background: theme.secondary,
+                color: getFontColor(theme.secondary),
+              }}
+            >
+              <MenuItem value="none">None</MenuItem>
+              <MenuItem value="daily">Daily</MenuItem>
+              <MenuItem value="weekly">Weekly</MenuItem>
+              <MenuItem value="monthly">Monthly</MenuItem>
+            </Select>
+          </div>
+        </InputThemeProvider>
+
         <ColorPicker
           color={color}
           width="400px"

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -1,9 +1,9 @@
-import { Category, Task } from "../types/user";
+import { Category, Task, Recurrence } from "../types/user";
 import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
 import { AddTaskRounded, CancelRounded } from "@mui/icons-material";
-import { IconButton, InputAdornment, Tooltip, Select, MenuItem } from "@mui/material";
+import { IconButton, InputAdornment, Tooltip, MenuItem } from "@mui/material";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../constants";
 import { ColorPicker, TopBar, CustomEmojiPicker } from "../components";
 import { UserContext } from "../contexts/UserContext";
@@ -27,6 +27,11 @@ const AddTask = () => {
     "sessionStorage",
   );
   const [deadline, setDeadline] = useStorageState<string>("", "deadline", "sessionStorage");
+  const [recurrence, setRecurrence] = useStorageState<Recurrence>(
+    "none",
+    "recurrence",
+    "sessionStorage",
+  );
   const [nameError, setNameError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
@@ -34,9 +39,6 @@ const AddTask = () => {
     "categories",
     "sessionStorage",
   );
-  const [recurrence, setRecurrence] = useStorageState<
-    "none" | "daily" | "weekly" | "monthly"
-  >("none", "recurrence", "sessionStorage");
 
   const [isDeadlineFocused, setIsDeadlineFocused] = useState<boolean>(false);
 
@@ -113,8 +115,8 @@ const AddTask = () => {
       color,
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
+      recurrence,
       category: selectedCategories ? selectedCategories : [],
-      ...(recurrence !== "none" ? { recurrence } : {}),
     };
 
     setUser((prevUser) => ({
@@ -133,7 +135,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -228,28 +238,19 @@ const AddTask = () => {
             </div>
           )}
         </InputThemeProvider>
-
-        {/* Recurrence selector */}
-        <InputThemeProvider>
-          <div style={{ marginBottom: "14px", width: "400px" }}>
-            <Select
-              fullWidth
-              value={recurrence}
-              onChange={(e) => setRecurrence(e.target.value as typeof recurrence)}
-              displayEmpty
-              sx={{
-                borderRadius: "16px",
-                background: theme.secondary,
-                color: getFontColor(theme.secondary),
-              }}
-            >
-              <MenuItem value="none">None</MenuItem>
-              <MenuItem value="daily">Daily</MenuItem>
-              <MenuItem value="weekly">Weekly</MenuItem>
-              <MenuItem value="monthly">Monthly</MenuItem>
-            </Select>
-          </div>
-        </InputThemeProvider>
+        {/* Recurrence selection */}
+        <StyledInput
+          select
+          label="Recurrence"
+          value={recurrence}
+          onChange={(e) => setRecurrence(e.target.value as Recurrence)}
+          sx={{ mt: 2, mb: 2 }}
+        >
+          <MenuItem value="none">None</MenuItem>
+          <MenuItem value="daily">Daily</MenuItem>
+          <MenuItem value="weekly">Weekly</MenuItem>
+          <MenuItem value="monthly">Monthly</MenuItem>
+        </StyledInput>
 
         <ColorPicker
           color={color}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -8,6 +8,11 @@ export type UUID = ReturnType<typeof crypto.randomUUID>;
 export type DarkModeOptions = "system" | "auto" | "light" | "dark";
 
 /**
+ * Allowed recurrence intervals for recurring tasks.
+ */
+export type Recurrence = "daily" | "weekly" | "monthly";
+
+/**
  * Represents a user in the application.
  */
 export interface User {
@@ -50,6 +55,11 @@ export interface Task {
    */
   date: Date;
   deadline?: Date;
+  /**
+   * Recurrence rule for automatically creating the next occurrence
+   * when the current task is completed.
+   */
+  recurrence?: Recurrence;
   category?: Category[];
   lastSave?: Date;
   sharedBy?: string;
@@ -57,13 +67,6 @@ export interface Task {
    * Optional numeric position for drag-and-drop (for p2p sync)
    */
   position?: number;
-  /**
-   * Optional recurrence pattern for the task.
-   * If provided, a new task instance will be generated when the task is marked as done.
-   *
-   * // Non-breaking: optional field added; existing tasks remain valid.
-   */
-  recurrence?: Recurrence;
 }
 
 /**
@@ -100,10 +103,3 @@ export interface AppSettings {
 
 export type SortOption = "dateCreated" | "dueDate" | "alphabetical" | "custom";
 export type ReduceMotionOption = "system" | "on" | "off";
-
-/**
- * Represents a supported recurrence interval for tasks.
- *
- * Non-breaking additive type: existing data without this field continues to work.
- */
-export type Recurrence = "daily" | "weekly" | "monthly";

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -60,6 +60,8 @@ export interface Task {
   /**
    * Optional recurrence pattern for the task.
    * If provided, a new task instance will be generated when the task is marked as done.
+   *
+   * // Non-breaking: optional field added; existing tasks remain valid.
    */
   recurrence?: Recurrence;
 }
@@ -101,5 +103,7 @@ export type ReduceMotionOption = "system" | "on" | "off";
 
 /**
  * Represents a supported recurrence interval for tasks.
+ *
+ * Non-breaking additive type: existing data without this field continues to work.
  */
 export type Recurrence = "daily" | "weekly" | "monthly";

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -57,6 +57,11 @@ export interface Task {
    * Optional numeric position for drag-and-drop (for p2p sync)
    */
   position?: number;
+  /**
+   * Optional recurrence pattern for the task.
+   * If provided, a new task instance will be generated when the task is marked as done.
+   */
+  recurrence?: Recurrence;
 }
 
 /**
@@ -93,3 +98,8 @@ export interface AppSettings {
 
 export type SortOption = "dateCreated" | "dueDate" | "alphabetical" | "custom";
 export type ReduceMotionOption = "system" | "on" | "off";
+
+/**
+ * Represents a supported recurrence interval for tasks.
+ */
+export type Recurrence = "daily" | "weekly" | "monthly";

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -8,11 +8,6 @@ export type UUID = ReturnType<typeof crypto.randomUUID>;
 export type DarkModeOptions = "system" | "auto" | "light" | "dark";
 
 /**
- * Allowed recurrence intervals for recurring tasks.
- */
-export type Recurrence = "daily" | "weekly" | "monthly";
-
-/**
  * Represents a user in the application.
  */
 export interface User {
@@ -56,8 +51,7 @@ export interface Task {
   date: Date;
   deadline?: Date;
   /**
-   * Recurrence rule for automatically creating the next occurrence
-   * when the current task is completed.
+   * Recurrence pattern for the task. If omitted or 'none', the task does not recur.
    */
   recurrence?: Recurrence;
   category?: Category[];
@@ -103,3 +97,5 @@ export interface AppSettings {
 
 export type SortOption = "dateCreated" | "dueDate" | "alphabetical" | "custom";
 export type ReduceMotionOption = "system" | "on" | "off";
+
+export type Recurrence = 'none' | 'daily' | 'weekly' | 'monthly';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,7 +5,12 @@ export { systemInfo } from "./getSystemInfo";
 export { saveQRCode } from "./saveQRCode";
 export { showToast } from "./showToast";
 export { generateUUID } from "./generateUUID";
-export { timeAgo, formatDate, calculateDateDifference } from "./timeUtils";
+export {
+  timeAgo,
+  formatDate,
+  calculateDateDifference,
+  getNextOccurrenceDate,
+} from "./timeUtils";
 export {
   initDB,
   deleteProfilePictureFromDB,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,7 @@ export { saveQRCode } from "./saveQRCode";
 export { showToast } from "./showToast";
 export { generateUUID } from "./generateUUID";
 export {
+  // Non-breaking additive exports: existing consumers remain unaffected.
   timeAgo,
   formatDate,
   calculateDateDifference,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,11 +6,10 @@ export { saveQRCode } from "./saveQRCode";
 export { showToast } from "./showToast";
 export { generateUUID } from "./generateUUID";
 export {
-  // Non-breaking additive exports: existing consumers remain unaffected.
   timeAgo,
   formatDate,
   calculateDateDifference,
-  getNextOccurrenceDate,
+  addInterval,
 } from "./timeUtils";
 export {
   initDB,

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -119,17 +119,20 @@ export const calculateDateDifference = (
 };
 
 /**
- * Calculates the next occurrence date based on the provided recurrence rule.
- * @param date      Current reference date.
- * @param recurrence Recurrence interval: "daily" | "weekly" | "monthly".
- * @returns A new `Date` representing the next occurrence.
- * (Non-breaking additive utility – existing code that doesn't use it is unaffected.)
+ * Returns a new Date shifted by the specified recurrence interval.
+ * For monthly recurrence, if the original day does not exist in the
+ * target month (e.g., 31 → Feb), the result is clamped to the last
+ * valid day of that month.
+ *
+ * @param date       The base date to shift.
+ * @param recurrence Recurrence interval: "daily", "weekly", or "monthly".
+ * @returns          A **new** Date instance representing the shifted date.
  */
-export const getNextOccurrenceDate = (
+export const addInterval = (
   date: Date,
   recurrence: "daily" | "weekly" | "monthly",
 ): Date => {
-  const next = new Date(date);
+  const next = new Date(date); // clone to avoid mutating original
 
   switch (recurrence) {
     case "daily":
@@ -138,12 +141,20 @@ export const getNextOccurrenceDate = (
     case "weekly":
       next.setDate(next.getDate() + 7);
       break;
-    case "monthly":
-      // JS Date auto-adjust handles month overflow (e.g., Jan 31 -> Feb 28/29)
+    case "monthly": {
+      const originalDay = next.getDate();
       next.setMonth(next.getMonth() + 1);
+      // If month overflowed (e.g., Jan 31 → Mar 3), clamp to last day
+      if (next.getDate() !== originalDay) {
+        // Setting date to 0 moves to the last day of previous month,
+        // which is the intended target after overflow.
+        next.setDate(0);
+      }
       break;
+    }
     default:
-      throw new Error(`Unsupported recurrence value: ${recurrence}`);
+      // Should not reach here, but return original date as safeguard
+      return new Date(date);
   }
 
   return next;

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -117,3 +117,33 @@ export const calculateDateDifference = (
   // beyond 7 days
   return rtf.format(dayDiff, "day");
 };
+
+/**
+ * Calculates the next occurrence date based on the provided recurrence rule.
+ * @param date      Current reference date.
+ * @param recurrence Recurrence interval: "daily" | "weekly" | "monthly".
+ * @returns A new `Date` representing the next occurrence.
+ */
+export const getNextOccurrenceDate = (
+  date: Date,
+  recurrence: "daily" | "weekly" | "monthly",
+): Date => {
+  const next = new Date(date);
+
+  switch (recurrence) {
+    case "daily":
+      next.setDate(next.getDate() + 1);
+      break;
+    case "weekly":
+      next.setDate(next.getDate() + 7);
+      break;
+    case "monthly":
+      // JS Date auto-adjust handles month overflow (e.g., Jan 31 -> Feb 28/29)
+      next.setMonth(next.getMonth() + 1);
+      break;
+    default:
+      throw new Error(`Unsupported recurrence value: ${recurrence}`);
+  }
+
+  return next;
+};

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -123,6 +123,7 @@ export const calculateDateDifference = (
  * @param date      Current reference date.
  * @param recurrence Recurrence interval: "daily" | "weekly" | "monthly".
  * @returns A new `Date` representing the next occurrence.
+ * (Non-breaking additive utility – existing code that doesn't use it is unaffected.)
  */
 export const getNextOccurrenceDate = (
   date: Date,


### PR DESCRIPTION
This is a Droid-assisted PR.

Summary
- Adds recurring task support with options: None, Daily, Weekly, Monthly.
- When a recurring task is marked complete, the next occurrence is created immediately with the due date shifted by the chosen interval.
- If a task has no deadline, no next occurrence is created (kept simple).

Key Changes
- types: introduce `Recurrence` type and optional `Task.recurrence`.
- utils: add `getNextOccurrenceDate(date, recurrence)`; re-exported from utils/index.
- AddTask: recurrence select stored in session; saved on task if not "None".
- EditTask: recurrence select; fixes to handle deadline as Date and keep recurrence string.
- TaskMenu: single mark-as-done creates next occurrence where applicable.
- TasksList: batch mark-as-done creates next occurrences where applicable.

Behavior Details
- New occurrence inherits name, description, emoji, color, categories, pinned, recurrence, and position; has new id, `done=false`, `date=now`, `deadline` shifted, and `lastSave` cleared.
- Monthly shift uses JS Date auto-adjust (e.g., Jan 31 -> Feb 28/29).

Testing Notes
- Create a task with a deadline and set recurrence to Daily/Weekly/Monthly.
- Mark it as done via the task menu or via multi-select; a new task should appear with a shifted deadline and `done=false`.
- If the task lacks a deadline, no new task is created upon completion.

No changes to task listing or details UI beyond the Add/Edit forms.


---
**Factory Session:** https://app.factory.ai/sessions/bcQPJsewXRFv3IKi5Ts7 (created by ethanzrd)