### PR TITLE
feat(tasks): add recurring tasks (daily/weekly/monthly) with auto next occurrence on complete

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -84,6 +84,10 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
             category: editedTask.category || undefined,
+            recurrence:
+              editedTask.recurrence && editedTask.recurrence !== "none"
+                ? editedTask.recurrence
+                : undefined,
             lastSave: new Date(),
           };
         }
@@ -241,7 +245,22 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
-
+        <StyledInput
+          select
+          label="Recurrence"
+          name="recurrence"
+          value={editedTask?.recurrence || "none"}
+          onChange={handleInputChange}
+          SelectProps={{ native: true }}
+          sx={{
+            mt: 2,
+          }}
+        >
+          <option value="none">Does not repeat</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+        </StyledInput>
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect
             fontColor={theme.darkmode ? ColorPalette.fontLight : ColorPalette.fontDark}

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -28,6 +28,7 @@ import { UserContext } from "../../contexts/UserContext";
 import { useResponsiveDisplay } from "../../hooks/useResponsiveDisplay";
 import { Task } from "../../types/user";
 import { calculateDateDifference, generateUUID, showToast } from "../../utils";
+import { addRecurrenceInterval } from "../../utils/timeUtils";
 import { useTheme } from "@emotion/react";
 import { TaskContext } from "../../contexts/TaskContext";
 import { ColorPalette } from "../../theme/themeConfig";
@@ -67,15 +68,41 @@ export const TaskMenu = () => {
   };
 
   const handleMarkAsDone = () => {
-    // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
-      const updatedTasks = tasks.map((task) => {
+
+      const target = tasks.find((t) => t.id === selectedTaskId);
+      const togglingToDone = target && !target.done;
+
+      let updatedTasks = tasks.map((task) => {
         if (task.id === selectedTaskId) {
           return { ...task, done: !task.done, lastSave: new Date() };
         }
         return task;
       });
+
+      if (
+        togglingToDone &&
+        target?.deadline &&
+        target?.recurrence &&
+        target.recurrence !== "none"
+      ) {
+        const nextDeadline = addRecurrenceInterval(
+          new Date(target.deadline),
+          target.recurrence as "daily" | "weekly" | "monthly",
+        );
+
+        const nextTask: Task = {
+          ...target,
+          id: generateUUID(),
+          done: false,
+          date: new Date(),
+          lastSave: undefined,
+          deadline: nextDeadline,
+        };
+        updatedTasks = [...updatedTasks, nextTask];
+      }
+
       setUser((prevUser) => ({
         ...prevUser,
         tasks: updatedTasks,

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -29,7 +29,8 @@ import { useStorageState } from "../../hooks/useStorageState";
 import { DialogBtn } from "../../styles";
 import { ColorPalette } from "../../theme/themeConfig";
 import type { Category, Task, UUID } from "../../types/user";
-import { getFontColor, showToast } from "../../utils";
+import { getFontColor, showToast, generateUUID } from "../../utils";
+import { addRecurrenceInterval } from "../../utils/timeUtils";
 import {
   NoTasks,
   RingAlarm,
@@ -267,17 +268,33 @@ export const TasksList: React.FC = () => {
   };
 
   const handleMarkSelectedAsDone = () => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      tasks: prevUser.tasks.map((task) => {
-        if (multipleSelectedTasks.includes(task.id)) {
-          // Mark the task as done if selected
-          return { ...task, done: true, lastSave: new Date() };
-        }
-        return task;
-      }),
-    }));
-    // Clear the selected task IDs after the operation
+    setUser((prevUser) => {
+      const newlyDoneIds = new Set(multipleSelectedTasks);
+      const updated = prevUser.tasks.map((task) =>
+        newlyDoneIds.has(task.id) ? { ...task, done: true, lastSave: new Date() } : task,
+      );
+
+      const toAppend: Task[] = prevUser.tasks
+        .filter(
+          (t) => newlyDoneIds.has(t.id) && t.deadline && t.recurrence && t.recurrence !== "none",
+        )
+        .map((t) => ({
+          ...t,
+          id: generateUUID(),
+          done: false,
+          date: new Date(),
+          lastSave: undefined,
+          deadline: addRecurrenceInterval(
+            new Date(t.deadline as Date),
+            t.recurrence as "daily" | "weekly" | "monthly",
+          ),
+        }));
+
+      return {
+        ...prevUser,
+        tasks: [...updated, ...toAppend],
+      };
+    });
     setMultipleSelectedTasks([]);
   };
 

--- a/src/contexts/UserProvider.tsx
+++ b/src/contexts/UserProvider.tsx
@@ -1,19 +1,59 @@
+import { useEffect } from "react";
 import { defaultUser } from "../constants/defaultUser";
 import { useStorageState } from "../hooks/useStorageState";
-import { User } from "../types/user";
+import { Task, User } from "../types/user";
 import { UserContext } from "./UserContext";
+
+function reviveDate(value: unknown): Date | unknown {
+  if (typeof value === "string") {
+    const d = new Date(value);
+    if (!isNaN(d.getTime())) return d;
+  }
+  return value;
+}
+
+function reviveTaskDates(task: Task): Task {
+  return {
+    ...task,
+    date: reviveDate(task.date) as Date,
+    deadline: task.deadline ? (reviveDate(task.deadline) as Date) : undefined,
+    lastSave: task.lastSave ? (reviveDate(task.lastSave) as Date) : undefined,
+  };
+}
+
+function reviveUserDates(user: User): User {
+  return {
+    ...user,
+    createdAt: reviveDate(user.createdAt) as Date,
+    lastSyncedAt: user.lastSyncedAt ? (reviveDate(user.lastSyncedAt) as Date) : undefined,
+    tasks: Array.isArray(user.tasks) ? user.tasks.map(reviveTaskDates) : [],
+    deletedTasks: user.deletedTasks,
+  };
+}
 
 export const UserContextProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useStorageState<User>(defaultUser, "user");
 
-  // const updateUser = <K extends keyof User>(
-  //   updater: (prevUser: User) => Pick<User, K> | Partial<User>,
-  // ): void => {
-  //   setUser((prevUser) => ({
-  //     ...prevUser,
-  //     ...updater(prevUser),
-  //   }));
-  // };
+  useEffect(() => {
+    const hasStringDatesInTasks = (arr: Task[]) =>
+      Array.isArray(arr) &&
+      arr.some(
+        (t) =>
+          typeof t.date === "string" ||
+          typeof t.deadline === "string" ||
+          typeof t.lastSave === "string",
+      );
+
+    const changed =
+      typeof user.createdAt === "string" ||
+      typeof user.lastSyncedAt === "string" ||
+      hasStringDatesInTasks(user.tasks);
+
+    if (changed) {
+      const revived = reviveUserDates(user);
+      setUser(revived);
+    }
+  }, [user, setUser]);
 
   return <UserContext.Provider value={{ user, setUser }}>{children}</UserContext.Provider>;
 };

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -34,6 +34,11 @@ const AddTask = () => {
     "categories",
     "sessionStorage",
   );
+  const [recurrence, setRecurrence] = useStorageState<"none" | "daily" | "weekly" | "monthly">(
+    "none",
+    "recurrence",
+    "sessionStorage",
+  );
 
   const [isDeadlineFocused, setIsDeadlineFocused] = useState<boolean>(false);
 
@@ -111,6 +116,7 @@ const AddTask = () => {
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
       category: selectedCategories ? selectedCategories : [],
+      recurrence: recurrence === "none" ? undefined : recurrence,
     };
 
     setUser((prevUser) => ({
@@ -129,7 +135,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -211,6 +225,24 @@ const AddTask = () => {
               },
             }}
           />
+          <StyledInput
+            select
+            label="Recurrence"
+            name="recurrence"
+            value={recurrence}
+            onChange={(e) =>
+              setRecurrence(e.target.value as "none" | "daily" | "weekly" | "monthly")
+            }
+            SelectProps={{ native: true }}
+            sx={{
+              mt: 1,
+            }}
+          >
+            <option value="none">Does not repeat</option>
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
+          </StyledInput>
 
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -34,6 +34,8 @@ export interface User {
   lastSyncedAt?: Date;
 }
 
+export type Recurrence = "none" | "daily" | "weekly" | "monthly";
+
 /**
  * Represents a task in the application.
  */
@@ -57,6 +59,7 @@ export interface Task {
    * Optional numeric position for drag-and-drop (for p2p sync)
    */
   position?: number;
+  recurrence?: Recurrence;
 }
 
 /**

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -117,3 +117,30 @@ export const calculateDateDifference = (
   // beyond 7 days
   return rtf.format(dayDiff, "day");
 };
+
+export const addRecurrenceInterval = (
+  date: Date,
+  recurrence: "daily" | "weekly" | "monthly",
+): Date => {
+  const d = new Date(date);
+  if (recurrence === "daily") {
+    d.setDate(d.getDate() + 1);
+    return d;
+  }
+  if (recurrence === "weekly") {
+    d.setDate(d.getDate() + 7);
+    return d;
+  }
+  const originalDay = d.getDate();
+  const originalHours = d.getHours();
+  const originalMinutes = d.getMinutes();
+  const originalSeconds = d.getSeconds();
+  const originalMs = d.getMilliseconds();
+  const next = new Date(d);
+  next.setMonth(next.getMonth() + 1);
+  if (next.getDate() !== originalDay) {
+    next.setDate(0);
+  }
+  next.setHours(originalHours, originalMinutes, originalSeconds, originalMs);
+  return next;
+};


### PR DESCRIPTION
# Add Recurring Tasks & Fix Refresh State Issues

## Summary

This PR implements recurring tasks functionality and fixes a critical refresh-state bug that was causing weird behavior after page reloads.

**Recurring Tasks Feature:**
- Added daily, weekly, and monthly recurrence options to task creation and editing
- When a recurring task with a deadline is marked complete, automatically creates the next occurrence with the deadline shifted by the recurrence interval
- Works for both single task completion and bulk task completion

**Refresh State Fix:**
- Fixed issue where task/user data became corrupted after page refresh due to Date fields being serialized as strings in localStorage but expected as Date objects by the app
- Added date revival logic in UserProvider that automatically converts string dates back to Date objects on app load
- Prevents weird mutations, duplications, and state inconsistencies after refresh

## Review & Testing Checklist for Human

- [ ] **Test recurring task creation end-to-end**: Create daily/weekly/monthly recurring tasks with deadlines, mark them complete, verify exactly one next occurrence is created with correctly shifted deadline
- [ ] **Test refresh stability**: Create tasks, mark some as done (including recurring ones), refresh the page multiple times, verify no task duplication or state corruption occurs
- [ ] **Test monthly recurrence edge cases**: Create monthly recurring tasks with deadlines on end-of-month dates (e.g., Jan 31, Feb 28), mark complete, verify next occurrence handles month boundaries correctly
- [ ] **Test bulk task completion**: Select multiple tasks including both recurring and non-recurring ones, mark all as done, verify recurring ones create next occurrences and non-recurring ones just complete
- [ ] **Verify non-recurring tasks still work**: Ensure regular task creation, editing, and completion workflows are unaffected

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    UserProvider["src/contexts/<br/>UserProvider.tsx"]:::major-edit
    TaskMenu["src/components/tasks/<br/>TaskMenu.tsx"]:::major-edit  
    TasksList["src/components/tasks/<br/>TasksList.tsx"]:::major-edit
    AddTask["src/pages/<br/>AddTask.tsx"]:::minor-edit
    EditTask["src/components/tasks/<br/>EditTask.tsx"]:::minor-edit
    timeUtils["src/utils/<br/>timeUtils.ts"]:::minor-edit
    userTypes["src/types/<br/>user.ts"]:::minor-edit
    
    UserProvider -->|"loads user data<br/>with date revival"| TaskMenu
    UserProvider -->|"loads user data<br/>with date revival"| TasksList
    TaskMenu -->|"creates next occurrence<br/>on completion"| timeUtils
    TasksList -->|"creates next occurrence<br/>on bulk completion"| timeUtils
    AddTask -->|"sets recurrence<br/>on new tasks"| userTypes
    EditTask -->|"updates recurrence<br/>on existing tasks"| userTypes
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- The date revival logic is designed to be idempotent and only runs when string dates are detected, preventing performance issues
- Monthly recurrence uses careful date math to handle month boundary edge cases (e.g., Jan 31 → Feb 28/29)
- Both single and bulk task completion handlers were updated to support recurring task creation
- The fix addresses the root cause of refresh-state issues that were causing user confusion

**Link to Devin run:** https://app.devin.ai/sessions/18b53b143d7942008a727d386d77f295  
**Requested by:** @ethanzrd