### PR TITLE
Add recurring tasks (daily/weekly/monthly) with auto-next occurrence

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -20,6 +20,8 @@ import { formatDate, showToast, timeAgo } from "../../utils";
 import { useTheme } from "@emotion/react";
 import { ColorPalette } from "../../theme/themeConfig";
 import { CategorySelect } from "../CategorySelect";
+import { FormControl, InputLabel, Select, MenuItem } from "@mui/material";
+import type { Recurrence } from "../../types/user";
 
 interface EditTaskProps {
   open: boolean;
@@ -84,6 +86,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
             category: editedTask.category || undefined,
+            recurrence: editedTask.recurrence || "none",
             lastSave: new Date(),
           };
         }
@@ -268,6 +271,27 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
               }));
             }}
           />
+          <FormControl sx={{ mt: 2, width: "100%" }}>
+            <InputLabel id="recurrence-edit-label">Recurrence</InputLabel>
+            <Select
+              labelId="recurrence-edit-label"
+              name="recurrence"
+              value={editedTask?.recurrence || "none"}
+              label="Recurrence"
+              onChange={(e) =>
+                setEditedTask((prev) => ({
+                  ...(prev as Task),
+                  recurrence: e.target.value as Recurrence,
+                }))
+              }
+              sx={{ maxWidth: 400 }}
+            >
+              <MenuItem value="none">None</MenuItem>
+              <MenuItem value="daily">Daily</MenuItem>
+              <MenuItem value="weekly">Weekly</MenuItem>
+              <MenuItem value="monthly">Monthly</MenuItem>
+            </Select>
+          </FormControl>
         </div>
       </DialogContent>
       <DialogActions>

--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -252,47 +252,38 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             onCategoryChange={(categories) => setSelectedCategories(categories)}
           />
         )}
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            marginTop: "8px",
+        <FormControl sx={{ mt: 2, width: "100%" }}>
+          <InputLabel id="recurrence-edit-label">Recurrence</InputLabel>
+          <Select
+            labelId="recurrence-edit-label"
+            name="recurrence"
+            value={editedTask?.recurrence || "none"}
+            label="Recurrence"
+            onChange={(e) =>
+              setEditedTask((prev) => ({
+                ...(prev as Task),
+                recurrence: e.target.value as Recurrence,
+              }))
+            }
+            sx={{ maxWidth: 400 }}
+          >
+            <MenuItem value="none">None</MenuItem>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </Select>
+        </FormControl>
+        <ColorPicker
+          width={"100%"}
+          color={editedTask?.color || "#000000"}
+          fontColor={theme.darkmode ? ColorPalette.fontLight : ColorPalette.fontDark}
+          onColorChange={(color) => {
+            setEditedTask((prevTask) => ({
+              ...(prevTask as Task),
+              color: color,
+            }));
           }}
-        >
-          <ColorPicker
-            width={"100%"}
-            color={editedTask?.color || "#000000"}
-            fontColor={theme.darkmode ? ColorPalette.fontLight : ColorPalette.fontDark}
-            onColorChange={(color) => {
-              setEditedTask((prevTask) => ({
-                ...(prevTask as Task),
-                color: color,
-              }));
-            }}
-          />
-          <FormControl sx={{ mt: 2, width: "100%" }}>
-            <InputLabel id="recurrence-edit-label">Recurrence</InputLabel>
-            <Select
-              labelId="recurrence-edit-label"
-              name="recurrence"
-              value={editedTask?.recurrence || "none"}
-              label="Recurrence"
-              onChange={(e) =>
-                setEditedTask((prev) => ({
-                  ...(prev as Task),
-                  recurrence: e.target.value as Recurrence,
-                }))
-              }
-              sx={{ maxWidth: 400 }}
-            >
-              <MenuItem value="none">None</MenuItem>
-              <MenuItem value="daily">Daily</MenuItem>
-              <MenuItem value="weekly">Weekly</MenuItem>
-              <MenuItem value="monthly">Monthly</MenuItem>
-            </Select>
-          </FormControl>
-        </div>
+        />
       </DialogContent>
       <DialogActions>
         <DialogBtn onClick={handleCancel}>Cancel</DialogBtn>

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -28,6 +28,7 @@ import { UserContext } from "../../contexts/UserContext";
 import { useResponsiveDisplay } from "../../hooks/useResponsiveDisplay";
 import { Task } from "../../types/user";
 import { calculateDateDifference, generateUUID, showToast } from "../../utils";
+import { shiftByRecurrence } from "../../utils/timeUtils";
 import { useTheme } from "@emotion/react";
 import { TaskContext } from "../../contexts/TaskContext";
 import { ColorPalette } from "../../theme/themeConfig";
@@ -67,18 +68,40 @@ export const TaskMenu = () => {
   };
 
   const handleMarkAsDone = () => {
-    // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
+      const original = tasks.find((t) => t.id === selectedTaskId);
+      const togglingToDone = original ? !original.done : false;
+
       const updatedTasks = tasks.map((task) => {
         if (task.id === selectedTaskId) {
           return { ...task, done: !task.done, lastSave: new Date() };
         }
         return task;
       });
+
+      let finalTasks = updatedTasks;
+
+      if (togglingToDone && original && original.recurrence && original.recurrence !== "none") {
+        const nextDeadline = original.deadline
+          ? shiftByRecurrence(new Date(original.deadline), original.recurrence)
+          : undefined;
+
+        const nextTask: Task = {
+          ...original,
+          id: generateUUID(),
+          done: false,
+          date: new Date(),
+          deadline: nextDeadline,
+          lastSave: undefined,
+        };
+
+        finalTasks = [...updatedTasks, nextTask];
+      }
+
       setUser((prevUser) => ({
         ...prevUser,
-        tasks: updatedTasks,
+        tasks: finalTasks,
       }));
 
       const allTasksDone = updatedTasks.every((task) => task.done);

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -29,7 +29,8 @@ import { useStorageState } from "../../hooks/useStorageState";
 import { DialogBtn } from "../../styles";
 import { ColorPalette } from "../../theme/themeConfig";
 import type { Category, Task, UUID } from "../../types/user";
-import { getFontColor, showToast } from "../../utils";
+import { getFontColor, showToast, generateUUID } from "../../utils";
+import { shiftByRecurrence } from "../../utils/timeUtils";
 import {
   NoTasks,
   RingAlarm,
@@ -267,17 +268,37 @@ export const TasksList: React.FC = () => {
   };
 
   const handleMarkSelectedAsDone = () => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      tasks: prevUser.tasks.map((task) => {
+    setUser((prevUser) => {
+      const originals = prevUser.tasks.filter((t) => multipleSelectedTasks.includes(t.id));
+
+      const updated = prevUser.tasks.map((task) => {
         if (multipleSelectedTasks.includes(task.id)) {
-          // Mark the task as done if selected
           return { ...task, done: true, lastSave: new Date() };
         }
         return task;
-      }),
-    }));
-    // Clear the selected task IDs after the operation
+      });
+
+      const nexts = originals
+        .filter((o) => o.recurrence && o.recurrence !== "none")
+        .map((o) => {
+          const nextDeadline = o.deadline
+            ? shiftByRecurrence(new Date(o.deadline), o.recurrence)
+            : undefined;
+          return {
+            ...o,
+            id: generateUUID(),
+            done: false,
+            date: new Date(),
+            deadline: nextDeadline,
+            lastSave: undefined,
+          };
+        });
+
+      return {
+        ...prevUser,
+        tasks: [...updated, ...nexts],
+      };
+    });
     setMultipleSelectedTasks([]);
   };
 

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -3,7 +3,15 @@ import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
 import { AddTaskRounded, CancelRounded } from "@mui/icons-material";
-import { IconButton, InputAdornment, Tooltip } from "@mui/material";
+import {
+  IconButton,
+  InputAdornment,
+  Tooltip,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from "@mui/material";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../constants";
 import { ColorPicker, TopBar, CustomEmojiPicker } from "../components";
 import { UserContext } from "../contexts/UserContext";
@@ -13,6 +21,7 @@ import { generateUUID, getFontColor, isDark, showToast } from "../utils";
 import { ColorPalette } from "../theme/themeConfig";
 import InputThemeProvider from "../contexts/InputThemeProvider";
 import { CategorySelect } from "../components/CategorySelect";
+import type { Recurrence } from "../types/user";
 import { useToasterStore } from "react-hot-toast";
 
 const AddTask = () => {
@@ -32,6 +41,11 @@ const AddTask = () => {
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
     [],
     "categories",
+    "sessionStorage",
+  );
+  const [recurrence, setRecurrence] = useStorageState<Recurrence>(
+    "none",
+    "recurrence",
     "sessionStorage",
   );
 
@@ -111,6 +125,7 @@ const AddTask = () => {
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
       category: selectedCategories ? selectedCategories : [],
+      recurrence: recurrence || "none",
     };
 
     setUser((prevUser) => ({
@@ -129,7 +144,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -223,6 +246,21 @@ const AddTask = () => {
               />
             </div>
           )}
+          <FormControl sx={{ mt: 2 }}>
+            <InputLabel id="recurrence-label">Recurrence</InputLabel>
+            <Select
+              labelId="recurrence-label"
+              value={recurrence}
+              label="Recurrence"
+              onChange={(e) => setRecurrence(e.target.value as Recurrence)}
+              sx={{ width: 400, color: getFontColor(theme.secondary) }}
+            >
+              <MenuItem value="none">None</MenuItem>
+              <MenuItem value="daily">Daily</MenuItem>
+              <MenuItem value="weekly">Weekly</MenuItem>
+              <MenuItem value="monthly">Monthly</MenuItem>
+            </Select>
+          </FormControl>
         </InputThemeProvider>
         <ColorPicker
           color={color}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -37,6 +37,8 @@ export interface User {
 /**
  * Represents a task in the application.
  */
+export type Recurrence = "none" | "daily" | "weekly" | "monthly";
+
 export interface Task {
   id: UUID;
   done: boolean;
@@ -53,6 +55,7 @@ export interface Task {
   category?: Category[];
   lastSave?: Date;
   sharedBy?: string;
+  recurrence?: Recurrence;
   /**
    * Optional numeric position for drag-and-drop (for p2p sync)
    */

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -117,3 +117,40 @@ export const calculateDateDifference = (
   // beyond 7 days
   return rtf.format(dayDiff, "day");
 };
+
+export const addDays = (date: Date, days: number): Date => {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+};
+
+const endOfMonth = (year: number, monthIndex: number): number => {
+  return new Date(year, monthIndex + 1, 0).getDate();
+};
+
+export const addMonthClamp = (date: Date): Date => {
+  const y = date.getFullYear();
+  const m = date.getMonth();
+  const d = date.getDate();
+  const targetMonth = m + 1;
+  const lastDayNextMonth = endOfMonth(y, targetMonth);
+  const day = Math.min(d, lastDayNextMonth);
+  return new Date(
+    y,
+    targetMonth,
+    day,
+    date.getHours(),
+    date.getMinutes(),
+    date.getSeconds(),
+    date.getMilliseconds(),
+  );
+};
+
+import type { Recurrence } from "../types/user";
+export const shiftByRecurrence = (date: Date, recurrence?: Recurrence): Date => {
+  if (!recurrence || recurrence === "none") return date;
+  if (recurrence === "daily") return addDays(date, 1);
+  if (recurrence === "weekly") return addDays(date, 7);
+  if (recurrence === "monthly") return addMonthClamp(date);
+  return date;
+};


### PR DESCRIPTION
# Add recurring tasks (daily/weekly/monthly) with auto-next occurrence

## Summary

This PR implements recurring task functionality, allowing users to select daily, weekly, or monthly recurrence when creating or editing tasks. When a recurring task is marked complete, the system automatically creates the next occurrence with the due date shifted by the chosen interval.

**Key Changes:**
- Added `Recurrence` type and optional `recurrence` field to Task interface for backward compatibility
- Implemented date shifting utilities with monthly edge case handling (e.g., Jan 31 → Feb 28/29)
- Added recurrence selectors to both AddTask and EditTask UI components
- Modified task completion logic in both single-task and multi-select scenarios to auto-generate next occurrences
- Preserved existing task storage/validation patterns

## Review & Testing Checklist for Human

- [ ] **End-to-end workflow**: Create a recurring task (daily/weekly/monthly), mark it complete, verify next occurrence is created with correct shifted deadline
- [ ] **Monthly edge cases**: Test tasks with deadlines on Jan 30/31, verify they properly clamp to Feb 28/29 when recurring monthly
- [ ] **Multi-select completion**: Select multiple recurring tasks, mark as done, verify all spawn next occurrences correctly  
- [ ] **UI persistence**: Create task with recurrence, edit it to change recurrence type, verify changes save and display properly
- [ ] **Backward compatibility**: Verify existing tasks without recurrence field still function normally (complete, edit, etc.)

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    AddTask["src/pages/AddTask.tsx<br/>Recurrence Selector"]:::major-edit
    EditTask["src/components/tasks/EditTask.tsx<br/>Recurrence Selector"]:::major-edit
    TaskTypes["src/types/user.ts<br/>Task + Recurrence Types"]:::major-edit
    TimeUtils["src/utils/timeUtils.ts<br/>Date Shifting Logic"]:::major-edit
    TaskMenu["src/components/tasks/TaskMenu.tsx<br/>Single Task Completion"]:::major-edit
    TasksList["src/components/tasks/TasksList.tsx<br/>Multi-Task Completion"]:::major-edit
    UserContext["UserContext<br/>Task Storage"]:::context

    AddTask --> TaskTypes
    EditTask --> TaskTypes
    TaskMenu --> TimeUtils
    TasksList --> TimeUtils
    TaskMenu --> TaskTypes
    TasksList --> TaskTypes
    AddTask --> UserContext
    EditTask --> UserContext
    TaskMenu --> UserContext
    TasksList --> UserContext

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90,stroke:#333,stroke-width:2px
    classDef minor-edit fill:#87CEEB,stroke:#333,stroke-width:2px
    classDef context fill:#f9f9f9,stroke:#333,stroke-width:1px
```

### Notes


- Monthly recurrence uses a "clamp" approach for edge cases (Jan 31 → Feb 28/29) rather than rolling to next month
- Recurrence defaults to "none" to maintain backward compatibility with existing tasks
- Both single-task completion (TaskMenu) and multi-select completion (TasksList) create next occurrences
- New tasks inherit all properties from original except: new ID, done=false, date=now, deadline=shifted, lastSave=undefined

**Session Info:**
- Link to Devin run: https://app.devin.ai/sessions/b54569d289924234a4ca84df45548d4b
- Requested by: Ethan Zerad (@ethanzrd)