### PR TITLE
Add recurring task support

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -67,7 +67,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
     // Update the editedTask state with the changed value.
     setEditedTask((prevTask) => ({
       ...(prevTask as Task),
-      [name]: value,
+      [name]: name === "recurrence" && value === "none" ? undefined : value,
     }));
   };
   // Event handler for saving the edited task.
@@ -84,6 +84,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
             category: editedTask.category || undefined,
+            recurrence: editedTask.recurrence || undefined,
             lastSave: new Date(),
           };
         }
@@ -241,6 +242,20 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
+
+        <StyledInput
+          label="Recurrence"
+          name="recurrence"
+          select
+          value={editedTask?.recurrence || "none"}
+          onChange={handleInputChange}
+          SelectProps={{ native: true }}
+        >
+          <option value="none">None</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+        </StyledInput>
 
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -27,7 +27,12 @@ import { TaskIcon, TaskItem } from "..";
 import { UserContext } from "../../contexts/UserContext";
 import { useResponsiveDisplay } from "../../hooks/useResponsiveDisplay";
 import { Task } from "../../types/user";
-import { calculateDateDifference, generateUUID, showToast } from "../../utils";
+import {
+  calculateDateDifference,
+  generateUUID,
+  getNextRecurrenceDate,
+  showToast,
+} from "../../utils";
 import { useTheme } from "@emotion/react";
 import { TaskContext } from "../../contexts/TaskContext";
 import { ColorPalette } from "../../theme/themeConfig";
@@ -70,18 +75,32 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
+      const additionalTasks: Task[] = [];
       const updatedTasks = tasks.map((task) => {
         if (task.id === selectedTaskId) {
-          return { ...task, done: !task.done, lastSave: new Date() };
+          const newDone = !task.done;
+          if (!task.done && newDone && task.recurrence) {
+            const nextTask: Task = {
+              ...task,
+              id: generateUUID(),
+              done: false,
+              date: new Date(),
+              deadline: task.deadline
+                ? getNextRecurrenceDate(new Date(task.deadline), task.recurrence)
+                : undefined,
+              lastSave: undefined,
+            };
+            additionalTasks.push(nextTask);
+          }
+          return { ...task, done: newDone, lastSave: new Date() };
         }
         return task;
       });
+      const allTasksDone = [...updatedTasks, ...additionalTasks].every((task) => task.done);
       setUser((prevUser) => ({
         ...prevUser,
-        tasks: updatedTasks,
+        tasks: [...updatedTasks, ...additionalTasks],
       }));
-
-      const allTasksDone = updatedTasks.every((task) => task.done);
 
       if (allTasksDone) {
         showToast(

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -29,7 +29,7 @@ import { useStorageState } from "../../hooks/useStorageState";
 import { DialogBtn } from "../../styles";
 import { ColorPalette } from "../../theme/themeConfig";
 import type { Category, Task, UUID } from "../../types/user";
-import { getFontColor, showToast } from "../../utils";
+import { getFontColor, showToast, generateUUID, getNextRecurrenceDate } from "../../utils";
 import {
   NoTasks,
   RingAlarm,
@@ -267,16 +267,29 @@ export const TasksList: React.FC = () => {
   };
 
   const handleMarkSelectedAsDone = () => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      tasks: prevUser.tasks.map((task) => {
+    setUser((prevUser) => {
+      const extras: Task[] = [];
+      const updated = prevUser.tasks.map((task) => {
         if (multipleSelectedTasks.includes(task.id)) {
-          // Mark the task as done if selected
+          if (!task.done && task.recurrence) {
+            const nextTask: Task = {
+              ...task,
+              id: generateUUID(),
+              done: false,
+              date: new Date(),
+              deadline: task.deadline
+                ? getNextRecurrenceDate(new Date(task.deadline), task.recurrence)
+                : undefined,
+              lastSave: undefined,
+            };
+            extras.push(nextTask);
+          }
           return { ...task, done: true, lastSave: new Date() };
         }
         return task;
-      }),
-    }));
+      });
+      return { ...prevUser, tasks: [...updated, ...extras] };
+    });
     // Clear the selected task IDs after the operation
     setMultipleSelectedTasks([]);
   };

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -1,4 +1,4 @@
-import { Category, Task } from "../types/user";
+import { Category, Task, Recurrence } from "../types/user";
 import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
@@ -27,6 +27,11 @@ const AddTask = () => {
     "sessionStorage",
   );
   const [deadline, setDeadline] = useStorageState<string>("", "deadline", "sessionStorage");
+  const [recurrence, setRecurrence] = useStorageState<Recurrence | "none">(
+    "none",
+    "recurrence",
+    "sessionStorage",
+  );
   const [nameError, setNameError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
@@ -111,6 +116,7 @@ const AddTask = () => {
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
       category: selectedCategories ? selectedCategories : [],
+      recurrence: recurrence !== "none" ? recurrence : undefined,
     };
 
     setUser((prevUser) => ({
@@ -129,7 +135,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -211,6 +225,19 @@ const AddTask = () => {
               },
             }}
           />
+          <StyledInput
+            label="Recurrence"
+            name="recurrence"
+            select
+            value={recurrence}
+            onChange={(e) => setRecurrence(e.target.value as Recurrence | "none")}
+            SelectProps={{ native: true }}
+          >
+            <option value="none">None</option>
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
+          </StyledInput>
 
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -6,6 +6,7 @@ import type { EmojiStyle } from "emoji-picker-react";
 export type UUID = ReturnType<typeof crypto.randomUUID>;
 
 export type DarkModeOptions = "system" | "auto" | "light" | "dark";
+export type Recurrence = "daily" | "weekly" | "monthly";
 
 /**
  * Represents a user in the application.
@@ -51,6 +52,7 @@ export interface Task {
   date: Date;
   deadline?: Date;
   category?: Category[];
+  recurrence?: Recurrence;
   lastSave?: Date;
   sharedBy?: string;
   /**

--- a/src/utils/__tests__/timeUtils.test.ts
+++ b/src/utils/__tests__/timeUtils.test.ts
@@ -1,4 +1,4 @@
-import { timeAgo, formatDate, calculateDateDifference } from "../timeUtils";
+import { timeAgo, formatDate, calculateDateDifference, getNextRecurrenceDate } from "../timeUtils";
 
 describe("Date Utility Functions", () => {
   beforeEach(() => {
@@ -156,6 +156,27 @@ describe("Date Utility Functions", () => {
 
       const result = calculateDateDifference(deadline);
       expect(result).toBe("in 5 hours");
+    });
+  });
+
+  describe("getNextRecurrenceDate", () => {
+    it("should add one day for daily recurrence", () => {
+      const base = new Date("2024-01-01T00:00:00");
+      const next = getNextRecurrenceDate(base, "daily");
+      expect(next.getDate()).toBe(2);
+    });
+
+    it("should add seven days for weekly recurrence", () => {
+      const base = new Date("2024-01-01T00:00:00");
+      const next = getNextRecurrenceDate(base, "weekly");
+      expect(next.getDate()).toBe(8);
+    });
+
+    it("should add one month for monthly recurrence", () => {
+      const base = new Date("2024-01-15T00:00:00");
+      const next = getNextRecurrenceDate(base, "monthly");
+      expect(next.getMonth()).toBe(1);
+      expect(next.getDate()).toBe(15);
     });
   });
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,7 +5,7 @@ export { systemInfo } from "./getSystemInfo";
 export { saveQRCode } from "./saveQRCode";
 export { showToast } from "./showToast";
 export { generateUUID } from "./generateUUID";
-export { timeAgo, formatDate, calculateDateDifference } from "./timeUtils";
+export { timeAgo, formatDate, calculateDateDifference, getNextRecurrenceDate } from "./timeUtils";
 export {
   initDB,
   deleteProfilePictureFromDB,

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -117,3 +117,22 @@ export const calculateDateDifference = (
   // beyond 7 days
   return rtf.format(dayDiff, "day");
 };
+
+export const getNextRecurrenceDate = (
+  date: Date,
+  recurrence: "daily" | "weekly" | "monthly",
+): Date => {
+  const next = new Date(date);
+  switch (recurrence) {
+    case "daily":
+      next.setDate(next.getDate() + 1);
+      break;
+    case "weekly":
+      next.setDate(next.getDate() + 7);
+      break;
+    case "monthly":
+      next.setMonth(next.getMonth() + 1);
+      break;
+  }
+  return next;
+};


### PR DESCRIPTION
## Summary
- allow tasks to specify a recurrence interval (daily/weekly/monthly)
- auto create next occurrence when completing recurring tasks
- add helper to compute next recurrence date with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a361de9504832bb8f10027a1c87a6a