### PR TITLE
Add recurring tasks (daily/weekly/monthly) with next occurrence on completion [Droid-assisted PR]

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -20,6 +20,8 @@ import { formatDate, showToast, timeAgo } from "../../utils";
 import { useTheme } from "@emotion/react";
 import { ColorPalette } from "../../theme/themeConfig";
 import { CategorySelect } from "../CategorySelect";
+import { MenuItem } from "@mui/material";
+import type { Recurrence } from "../../types/user";
 
 interface EditTaskProps {
   open: boolean;
@@ -84,6 +86,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
             category: editedTask.category || undefined,
+            recurrence: editedTask.recurrence || "none",
             lastSave: new Date(),
           };
         }
@@ -241,6 +244,18 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
+        <StyledInput
+          label="Recurrence"
+          name="recurrence"
+          select
+          value={editedTask?.recurrence || "none"}
+          onChange={handleInputChange}
+        >
+          <MenuItem value="none">None</MenuItem>
+          <MenuItem value="daily">Daily</MenuItem>
+          <MenuItem value="weekly">Weekly</MenuItem>
+          <MenuItem value="monthly">Monthly</MenuItem>
+        </StyledInput>
 
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -27,7 +27,12 @@ import { TaskIcon, TaskItem } from "..";
 import { UserContext } from "../../contexts/UserContext";
 import { useResponsiveDisplay } from "../../hooks/useResponsiveDisplay";
 import { Task } from "../../types/user";
-import { calculateDateDifference, generateUUID, showToast } from "../../utils";
+import {
+  calculateDateDifference,
+  generateUUID,
+  showToast,
+  shiftDateByRecurrence,
+} from "../../utils";
 import { useTheme } from "@emotion/react";
 import { TaskContext } from "../../contexts/TaskContext";
 import { ColorPalette } from "../../theme/themeConfig";
@@ -76,6 +81,27 @@ export const TaskMenu = () => {
         }
         return task;
       });
+
+      const originalTask = tasks.find((t) => t.id === selectedTaskId);
+      if (
+        originalTask &&
+        !originalTask.done &&
+        originalTask.recurrence &&
+        originalTask.recurrence !== "none"
+      ) {
+        const nextTask: Task = {
+          ...originalTask,
+          id: generateUUID(),
+          done: false,
+          date: new Date(),
+          deadline: originalTask.deadline
+            ? shiftDateByRecurrence(new Date(originalTask.deadline), originalTask.recurrence)
+            : undefined,
+          lastSave: undefined,
+        };
+        updatedTasks.push(nextTask);
+      }
+
       setUser((prevUser) => ({
         ...prevUser,
         tasks: updatedTasks,

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -29,7 +29,12 @@ import { useStorageState } from "../../hooks/useStorageState";
 import { DialogBtn } from "../../styles";
 import { ColorPalette } from "../../theme/themeConfig";
 import type { Category, Task, UUID } from "../../types/user";
-import { getFontColor, showToast } from "../../utils";
+import {
+  getFontColor,
+  showToast,
+  shiftDateByRecurrence,
+  generateUUID,
+} from "../../utils";
 import {
   NoTasks,
   RingAlarm,
@@ -267,16 +272,40 @@ export const TasksList: React.FC = () => {
   };
 
   const handleMarkSelectedAsDone = () => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      tasks: prevUser.tasks.map((task) => {
+    setUser((prevUser) => {
+      const updatedTasks = prevUser.tasks.map((task) => {
         if (multipleSelectedTasks.includes(task.id)) {
-          // Mark the task as done if selected
           return { ...task, done: true, lastSave: new Date() };
         }
         return task;
-      }),
-    }));
+      });
+
+      const newTasksToAdd: Task[] = [];
+      prevUser.tasks.forEach((task) => {
+        if (
+          multipleSelectedTasks.includes(task.id) &&
+          !task.done &&
+          task.recurrence &&
+          task.recurrence !== "none"
+        ) {
+          newTasksToAdd.push({
+            ...task,
+            id: generateUUID(),
+            done: false,
+            date: new Date(),
+            deadline: task.deadline
+              ? shiftDateByRecurrence(new Date(task.deadline), task.recurrence)
+              : undefined,
+            lastSave: undefined,
+          });
+        }
+      });
+
+      return {
+        ...prevUser,
+        tasks: [...updatedTasks, ...newTasksToAdd],
+      };
+    });
     // Clear the selected task IDs after the operation
     setMultipleSelectedTasks([]);
   };

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -14,6 +14,8 @@ import { ColorPalette } from "../theme/themeConfig";
 import InputThemeProvider from "../contexts/InputThemeProvider";
 import { CategorySelect } from "../components/CategorySelect";
 import { useToasterStore } from "react-hot-toast";
+import type { Recurrence } from "../types/user";
+import { MenuItem } from "@mui/material";
 
 const AddTask = () => {
   const { user, setUser } = useContext(UserContext);
@@ -32,6 +34,11 @@ const AddTask = () => {
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
     [],
     "categories",
+    "sessionStorage",
+  );
+  const [recurrence, setRecurrence] = useStorageState<Recurrence>(
+    "none",
+    "recurrence",
     "sessionStorage",
   );
 
@@ -111,6 +118,7 @@ const AddTask = () => {
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
       category: selectedCategories ? selectedCategories : [],
+      recurrence,
     };
 
     setUser((prevUser) => ({
@@ -130,7 +138,7 @@ const AddTask = () => {
     );
 
     const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
-    itemsToRemove.map((item) => sessionStorage.removeItem(item));
+    itemsToRemove.concat("recurrence").map((item) => sessionStorage.removeItem(item));
   };
 
   return (
@@ -211,6 +219,20 @@ const AddTask = () => {
               },
             }}
           />
+
+          <StyledInput
+            label="Recurrence"
+            select
+            value={recurrence}
+            onChange={(e) => setRecurrence(e.target.value as Recurrence)}
+            helperText="Choose how often this task repeats"
+            sx={{ width: "400px" }}
+          >
+            <MenuItem value="none">None</MenuItem>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </StyledInput>
 
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -50,6 +50,11 @@ export interface Task {
    */
   date: Date;
   deadline?: Date;
+  /**
+   * Recurrence interval for the task.
+   * "none" (default) means the task does not repeat.
+   */
+  recurrence?: Recurrence;
   category?: Category[];
   lastSave?: Date;
   sharedBy?: string;
@@ -58,6 +63,11 @@ export interface Task {
    */
   position?: number;
 }
+
+/**
+ * Supported recurrence intervals for tasks.
+ */
+export type Recurrence = "none" | "daily" | "weekly" | "monthly";
 
 /**
  * Represents a category in the application.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,7 +5,12 @@ export { systemInfo } from "./getSystemInfo";
 export { saveQRCode } from "./saveQRCode";
 export { showToast } from "./showToast";
 export { generateUUID } from "./generateUUID";
-export { timeAgo, formatDate, calculateDateDifference } from "./timeUtils";
+export {
+  timeAgo,
+  formatDate,
+  calculateDateDifference,
+  shiftDateByRecurrence,
+} from "./timeUtils";
 export {
   initDB,
   deleteProfilePictureFromDB,

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -117,3 +117,24 @@ export const calculateDateDifference = (
   // beyond 7 days
   return rtf.format(dayDiff, "day");
 };
+
+import type { Recurrence } from "../types/user";
+
+export const shiftDateByRecurrence = (date: Date, recurrence: Recurrence): Date => {
+  const d = new Date(date);
+  switch (recurrence) {
+    case "daily":
+      d.setDate(d.getDate() + 1);
+      break;
+    case "weekly":
+      d.setDate(d.getDate() + 7);
+      break;
+    case "monthly":
+      d.setMonth(d.getMonth() + 1);
+      break;
+    default:
+      // 'none' or unknown value – no change
+      break;
+  }
+  return d;
+};


### PR DESCRIPTION
This PR adds simple recurring task support.

What’s included
- Recurrence options on task: none, daily, weekly, monthly (optional on Task)
- AddTask: recurrence selector; persisted to new tasks
- EditTask: recurrence selector; saved when editing
- On completion (single/bulk): if task is recurring and was not done previously, immediately create next occurrence with:
  - id: new UUID
  - done: false
  - date: now
  - deadline: shifted by interval if original has deadline; unchanged (undefined) if original had none (Option A)
- Helper `shiftDateByRecurrence` in `timeUtils`

Files touched
- src/types/user.ts
- src/utils/timeUtils.ts
- src/utils/index.ts
- src/pages/AddTask.tsx
- src/components/tasks/EditTask.tsx
- src/components/tasks/TaskMenu.tsx
- src/components/tasks/TasksList.tsx

Notes
- Kept changes minimal and inline with existing patterns.
- Could not run local tests/lints in this environment; please run CI to validate. Functionally scoped TS changes; no external deps.

Manual test checklist
- Create tasks with None/Daily/Weekly/Monthly and with/without deadline; mark as done → expected next occurrence behavior
- Bulk complete multiple recurring tasks → each spawns next
- Edit recurrence on existing task and verify behavior

This is a Droid-assisted PR.

---
**Factory Session:** https://app.factory.ai/sessions/IJTQw5h8XpgNFqmk4sIz (created by ethanzrd)