### PR TITLE
Add recurring task support

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -6,6 +6,7 @@ import {
   DialogContent,
   IconButton,
   InputAdornment,
+  MenuItem,
   TextField,
   TextFieldProps,
   Tooltip,
@@ -33,6 +34,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
   const [editedTask, setEditedTask] = useState<Task | undefined>(task);
   const [emoji, setEmoji] = useState<string | null>(null);
   const [selectedCategories, setSelectedCategories] = useState<Category[]>([]);
+  const [recurrence, setRecurrence] = useState<string>("none");
 
   const theme = useTheme();
 
@@ -58,6 +60,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
   useEffect(() => {
     setEditedTask(task);
     setSelectedCategories(task?.category as Category[]);
+    setRecurrence(task?.recurrence || "none");
   }, [task]);
 
   // Event handler for input changes in the form fields.
@@ -83,6 +86,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             emoji: editedTask.emoji || undefined,
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
+            recurrence: recurrence === "none" ? undefined : (recurrence as Task["recurrence"]),
             category: editedTask.category || undefined,
             lastSave: new Date(),
           };
@@ -106,6 +110,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
     onClose();
     setEditedTask(task);
     setSelectedCategories(task?.category as Category[]);
+    setRecurrence(task?.recurrence || "none");
   };
 
   useEffect(() => {
@@ -117,7 +122,9 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
 
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      if (JSON.stringify(editedTask) !== JSON.stringify(task) && open) {
+      const current = { ...editedTask, recurrence };
+      const original = { ...task, recurrence: task?.recurrence };
+      if (JSON.stringify(current) !== JSON.stringify(original) && open) {
         const message = "You have unsaved changes. Are you sure you want to leave?";
         e.returnValue = message;
         return message;
@@ -129,7 +136,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
     return () => {
       window.removeEventListener("beforeunload", handleBeforeUnload);
     };
-  }, [editedTask, open, task]);
+  }, [editedTask, open, task, recurrence]);
 
   return (
     <Dialog
@@ -241,6 +248,19 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
+
+        <StyledInput
+          select
+          label="Recurrence"
+          value={recurrence}
+          onChange={(e) => setRecurrence(e.target.value)}
+          sx={{ mt: 2 }}
+        >
+          <MenuItem value="none">None</MenuItem>
+          <MenuItem value="daily">Daily</MenuItem>
+          <MenuItem value="weekly">Weekly</MenuItem>
+          <MenuItem value="monthly">Monthly</MenuItem>
+        </StyledInput>
 
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -27,7 +27,7 @@ import { TaskIcon, TaskItem } from "..";
 import { UserContext } from "../../contexts/UserContext";
 import { useResponsiveDisplay } from "../../hooks/useResponsiveDisplay";
 import { Task } from "../../types/user";
-import { calculateDateDifference, generateUUID, showToast } from "../../utils";
+import { calculateDateDifference, generateUUID, getNextDueDate, showToast } from "../../utils";
 import { useTheme } from "@emotion/react";
 import { TaskContext } from "../../contexts/TaskContext";
 import { ColorPalette } from "../../theme/themeConfig";
@@ -70,11 +70,27 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
-      const updatedTasks = tasks.map((task) => {
+      const updatedTasks: Task[] = [];
+      tasks.forEach((task) => {
         if (task.id === selectedTaskId) {
-          return { ...task, done: !task.done, lastSave: new Date() };
+          const wasDone = task.done;
+          const toggled = { ...task, done: !task.done, lastSave: new Date() };
+          updatedTasks.push(toggled);
+          if (!wasDone && task.recurrence) {
+            updatedTasks.push({
+              ...task,
+              id: generateUUID(),
+              done: false,
+              date: new Date(),
+              deadline: task.deadline
+                ? getNextDueDate(new Date(task.deadline), task.recurrence)
+                : undefined,
+              lastSave: new Date(),
+            });
+          }
+        } else {
+          updatedTasks.push(task);
         }
-        return task;
       });
       setUser((prevUser) => ({
         ...prevUser,

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -29,7 +29,7 @@ import { useStorageState } from "../../hooks/useStorageState";
 import { DialogBtn } from "../../styles";
 import { ColorPalette } from "../../theme/themeConfig";
 import type { Category, Task, UUID } from "../../types/user";
-import { getFontColor, showToast } from "../../utils";
+import { getFontColor, showToast, generateUUID, getNextDueDate } from "../../utils";
 import {
   NoTasks,
   RingAlarm,
@@ -267,16 +267,29 @@ export const TasksList: React.FC = () => {
   };
 
   const handleMarkSelectedAsDone = () => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      tasks: prevUser.tasks.map((task) => {
+    setUser((prevUser) => {
+      const updatedTasks: Task[] = [];
+      prevUser.tasks.forEach((task) => {
         if (multipleSelectedTasks.includes(task.id)) {
-          // Mark the task as done if selected
-          return { ...task, done: true, lastSave: new Date() };
+          updatedTasks.push({ ...task, done: true, lastSave: new Date() });
+          if (task.recurrence) {
+            updatedTasks.push({
+              ...task,
+              id: generateUUID(),
+              done: false,
+              date: new Date(),
+              deadline: task.deadline
+                ? getNextDueDate(new Date(task.deadline), task.recurrence)
+                : undefined,
+              lastSave: new Date(),
+            });
+          }
+        } else {
+          updatedTasks.push(task);
         }
-        return task;
-      }),
-    }));
+      });
+      return { ...prevUser, tasks: updatedTasks };
+    });
     // Clear the selected task IDs after the operation
     setMultipleSelectedTasks([]);
   };

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
 import { AddTaskRounded, CancelRounded } from "@mui/icons-material";
-import { IconButton, InputAdornment, Tooltip } from "@mui/material";
+import { IconButton, InputAdornment, Tooltip, MenuItem } from "@mui/material";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../constants";
 import { ColorPicker, TopBar, CustomEmojiPicker } from "../components";
 import { UserContext } from "../contexts/UserContext";
@@ -27,6 +27,11 @@ const AddTask = () => {
     "sessionStorage",
   );
   const [deadline, setDeadline] = useStorageState<string>("", "deadline", "sessionStorage");
+  const [recurrence, setRecurrence] = useStorageState<string>(
+    "none",
+    "recurrence",
+    "sessionStorage",
+  );
   const [nameError, setNameError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
@@ -110,6 +115,7 @@ const AddTask = () => {
       color,
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
+      recurrence: recurrence !== "none" ? (recurrence as Task["recurrence"]) : undefined,
       category: selectedCategories ? selectedCategories : [],
     };
 
@@ -129,7 +135,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -211,6 +225,18 @@ const AddTask = () => {
               },
             }}
           />
+
+          <StyledInput
+            select
+            label="Recurrence"
+            value={recurrence}
+            onChange={(e) => setRecurrence(e.target.value)}
+          >
+            <MenuItem value="none">None</MenuItem>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </StyledInput>
 
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>

--- a/src/pages/TaskDetails.tsx
+++ b/src/pages/TaskDetails.tsx
@@ -90,6 +90,12 @@ const TaskDetails = () => {
                 <TableData>{dateFormatter.format(new Date(task.deadline))}</TableData>
               </TableRow>
             )}
+            {task?.recurrence && (
+              <TableRow>
+                <TableHeader>Recurrence:</TableHeader>
+                <TableData>{task.recurrence}</TableData>
+              </TableRow>
+            )}
             <TableRow>
               <TableHeader>Done:</TableHeader>
               <TableData>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -50,6 +50,10 @@ export interface Task {
    */
   date: Date;
   deadline?: Date;
+  /**
+   * Recurrence interval for the task.
+   */
+  recurrence?: "daily" | "weekly" | "monthly";
   category?: Category[];
   lastSave?: Date;
   sharedBy?: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,7 @@ export { saveQRCode } from "./saveQRCode";
 export { showToast } from "./showToast";
 export { generateUUID } from "./generateUUID";
 export { timeAgo, formatDate, calculateDateDifference } from "./timeUtils";
+export { getNextDueDate } from "./recurrence";
 export {
   initDB,
   deleteProfilePictureFromDB,

--- a/src/utils/recurrence.ts
+++ b/src/utils/recurrence.ts
@@ -1,0 +1,22 @@
+export type Recurrence = "daily" | "weekly" | "monthly";
+
+/**
+ * Returns the next due date based on recurrence interval.
+ */
+export const getNextDueDate = (current: Date, recurrence: Recurrence): Date => {
+  const next = new Date(current);
+  switch (recurrence) {
+    case "daily":
+      next.setDate(next.getDate() + 1);
+      break;
+    case "weekly":
+      next.setDate(next.getDate() + 7);
+      break;
+    case "monthly":
+      next.setMonth(next.getMonth() + 1);
+      break;
+    default:
+      break;
+  }
+  return next;
+};


### PR DESCRIPTION
## Summary
- allow choosing daily, weekly, or monthly recurrence when creating or editing a task
- automatically create the next occurrence when marking a recurring task complete
- show recurrence info in task details

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a72376dacc832b94d5b70b3712591d