### PR TITLE
Add recurring task support

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -9,6 +9,7 @@ import {
   TextField,
   TextFieldProps,
   Tooltip,
+  MenuItem, // options for the recurrence dropdown
 } from "@mui/material";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { ColorPicker, CustomDialogTitle, CustomEmojiPicker } from "..";
@@ -84,6 +85,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
             category: editedTask.category || undefined,
+            recurrence: editedTask.recurrence || undefined, // save selected recurrence if any
             lastSave: new Date(),
           };
         }
@@ -241,6 +243,19 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
+
+        <StyledInput
+          label="Recurrence"
+          name="recurrence"
+          select
+          value={editedTask?.recurrence || "none"}
+          onChange={handleInputChange}
+        >
+          <MenuItem value="none">None</MenuItem>
+          <MenuItem value="daily">Daily</MenuItem>
+          <MenuItem value="weekly">Weekly</MenuItem>
+          <MenuItem value="monthly">Monthly</MenuItem>
+        </StyledInput>
 
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect

--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -85,7 +85,8 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
             category: editedTask.category || undefined,
-            recurrence: editedTask.recurrence || undefined, // save selected recurrence if any
+            recurrence: editedTask.recurrence || undefined, // persist the chosen recurrence interval (daily/weekly/monthly)
+            // and omit the field entirely for one-off tasks
             lastSave: new Date(),
           };
         }

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -27,7 +27,12 @@ import { TaskIcon, TaskItem } from "..";
 import { UserContext } from "../../contexts/UserContext";
 import { useResponsiveDisplay } from "../../hooks/useResponsiveDisplay";
 import { Task } from "../../types/user";
-import { calculateDateDifference, generateUUID, showToast } from "../../utils";
+import {
+  calculateDateDifference,
+  generateUUID,
+  showToast,
+  createNextRecurringTask,
+} from "../../utils";
 import { useTheme } from "@emotion/react";
 import { TaskContext } from "../../contexts/TaskContext";
 import { ColorPalette } from "../../theme/themeConfig";
@@ -70,18 +75,24 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
+      let nextTask: Task | null = null;
       const updatedTasks = tasks.map((task) => {
         if (task.id === selectedTaskId) {
-          return { ...task, done: !task.done, lastSave: new Date() };
+          const newDone = !task.done;
+          if (!task.done && newDone) {
+            nextTask = createNextRecurringTask(task);
+          }
+          return { ...task, done: newDone, lastSave: new Date() };
         }
         return task;
       });
+      const finalTasks = nextTask ? [...updatedTasks, nextTask] : updatedTasks;
       setUser((prevUser) => ({
         ...prevUser,
-        tasks: updatedTasks,
+        tasks: finalTasks,
       }));
 
-      const allTasksDone = updatedTasks.every((task) => task.done);
+      const allTasksDone = finalTasks.every((task) => task.done);
 
       if (allTasksDone) {
         showToast(

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -29,7 +29,7 @@ import { useStorageState } from "../../hooks/useStorageState";
 import { DialogBtn } from "../../styles";
 import { ColorPalette } from "../../theme/themeConfig";
 import type { Category, Task, UUID } from "../../types/user";
-import { getFontColor, showToast } from "../../utils";
+import { getFontColor, showToast, createNextRecurringTask } from "../../utils";
 import {
   NoTasks,
   RingAlarm,
@@ -267,16 +267,23 @@ export const TasksList: React.FC = () => {
   };
 
   const handleMarkSelectedAsDone = () => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      tasks: prevUser.tasks.map((task) => {
+    setUser((prevUser) => {
+      const nextTasks: Task[] = [];
+      const updated = prevUser.tasks.map((task) => {
         if (multipleSelectedTasks.includes(task.id)) {
-          // Mark the task as done if selected
+          if (!task.done) {
+            const newTask = createNextRecurringTask(task);
+            if (newTask) nextTasks.push(newTask);
+          }
           return { ...task, done: true, lastSave: new Date() };
         }
         return task;
-      }),
-    }));
+      });
+      return {
+        ...prevUser,
+        tasks: [...updated, ...nextTasks],
+      };
+    });
     // Clear the selected task IDs after the operation
     setMultipleSelectedTasks([]);
   };

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
 import { AddTaskRounded, CancelRounded } from "@mui/icons-material";
-import { IconButton, InputAdornment, Tooltip } from "@mui/material";
+import { IconButton, InputAdornment, Tooltip, MenuItem } from "@mui/material";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../constants";
 import { ColorPicker, TopBar, CustomEmojiPicker } from "../components";
 import { UserContext } from "../contexts/UserContext";
@@ -27,6 +27,11 @@ const AddTask = () => {
     "sessionStorage",
   );
   const [deadline, setDeadline] = useStorageState<string>("", "deadline", "sessionStorage");
+  const [recurrence, setRecurrence] = useStorageState<string>(
+    "none",
+    "recurrence",
+    "sessionStorage",
+  );
   const [nameError, setNameError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
@@ -85,6 +90,10 @@ const AddTask = () => {
     setDeadline(event.target.value);
   };
 
+  const handleRecurrenceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setRecurrence(event.target.value);
+  };
+
   const handleAddTask = () => {
     if (name === "") {
       showToast("Task name is required.", {
@@ -111,6 +120,7 @@ const AddTask = () => {
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
       category: selectedCategories ? selectedCategories : [],
+      recurrence: recurrence !== "none" ? (recurrence as Task["recurrence"]) : undefined,
     };
 
     setUser((prevUser) => ({
@@ -129,7 +139,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -211,6 +229,19 @@ const AddTask = () => {
               },
             }}
           />
+
+          <StyledInput
+            label="Recurrence"
+            name="recurrence"
+            select
+            value={recurrence}
+            onChange={handleRecurrenceChange}
+          >
+            <MenuItem value="none">None</MenuItem>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </StyledInput>
 
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>

--- a/src/pages/TaskDetails.tsx
+++ b/src/pages/TaskDetails.tsx
@@ -90,6 +90,12 @@ const TaskDetails = () => {
                 <TableData>{dateFormatter.format(new Date(task.deadline))}</TableData>
               </TableRow>
             )}
+            {task?.recurrence && (
+              <TableRow>
+                <TableHeader>Recurrence:</TableHeader>
+                <TableData>{task.recurrence}</TableData>
+              </TableRow>
+            )}
             <TableRow>
               <TableHeader>Done:</TableHeader>
               <TableData>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -7,6 +7,8 @@ export type UUID = ReturnType<typeof crypto.randomUUID>;
 
 export type DarkModeOptions = "system" | "auto" | "light" | "dark";
 
+export type Recurrence = "daily" | "weekly" | "monthly";
+
 /**
  * Represents a user in the application.
  */
@@ -50,6 +52,10 @@ export interface Task {
    */
   date: Date;
   deadline?: Date;
+  /**
+   * Task recurrence interval
+   */
+  recurrence?: Recurrence;
   category?: Category[];
   lastSave?: Date;
   sharedBy?: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -16,3 +16,4 @@ export {
   optimizeProfilePicture,
   ALLOWED_PFP_TYPES,
 } from "./profilePictureStorage";
+export { createNextRecurringTask } from "./recurrence";

--- a/src/utils/recurrence.ts
+++ b/src/utils/recurrence.ts
@@ -1,0 +1,28 @@
+import { Task } from "../types/user";
+import { generateUUID } from "./generateUUID";
+
+export const createNextRecurringTask = (task: Task): Task | null => {
+  if (!task.recurrence || !task.deadline) return null;
+  const nextDeadline = new Date(task.deadline);
+  switch (task.recurrence) {
+    case "daily":
+      nextDeadline.setDate(nextDeadline.getDate() + 1);
+      break;
+    case "weekly":
+      nextDeadline.setDate(nextDeadline.getDate() + 7);
+      break;
+    case "monthly":
+      nextDeadline.setMonth(nextDeadline.getMonth() + 1);
+      break;
+    default:
+      return null;
+  }
+  return {
+    ...task,
+    id: generateUUID(),
+    done: false,
+    date: new Date(),
+    deadline: nextDeadline,
+    lastSave: undefined,
+  };
+};


### PR DESCRIPTION
## Summary
- allow selecting daily, weekly, or monthly recurrence when creating or editing tasks
- generate the next task occurrence with shifted deadline after completing a recurring task
- expose recurrence details in task view and shared utilities
- clarify recurrence dropdown and save comment for future maintainers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a717874e60832bb26ab92daebef7df