### PR TITLE
feat: add recurring task support

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -9,6 +9,7 @@ import {
   TextField,
   TextFieldProps,
   Tooltip,
+  MenuItem,
 } from "@mui/material";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { ColorPicker, CustomDialogTitle, CustomEmojiPicker } from "..";
@@ -83,6 +84,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             emoji: editedTask.emoji || undefined,
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
+            recurrence: editedTask.recurrence || undefined,
             category: editedTask.category || undefined,
             lastSave: new Date(),
           };
@@ -241,6 +243,19 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
+
+        <StyledInput
+          label="Recurrence"
+          name="recurrence"
+          select
+          value={editedTask?.recurrence || ""}
+          onChange={handleInputChange}
+        >
+          <MenuItem value="">None</MenuItem>
+          <MenuItem value="daily">Daily</MenuItem>
+          <MenuItem value="weekly">Weekly</MenuItem>
+          <MenuItem value="monthly">Monthly</MenuItem>
+        </StyledInput>
 
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -70,10 +70,12 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
+      // Hold any new recurring tasks to append later so the map below isn't mutated mid-iteration
       const additionalTasks: Task[] = [];
       const updatedTasks = tasks.map((task) => {
         if (task.id === selectedTaskId) {
           const willBeDone = !task.done;
+          // When completing a recurring task, queue up its next occurrence without altering existing tasks
           if (willBeDone && task.recurrence) {
             const nextDeadline = (() => {
               if (!task.deadline) return undefined;

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -70,18 +70,47 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
+      const additionalTasks: Task[] = [];
       const updatedTasks = tasks.map((task) => {
         if (task.id === selectedTaskId) {
-          return { ...task, done: !task.done, lastSave: new Date() };
+          const willBeDone = !task.done;
+          if (willBeDone && task.recurrence) {
+            const nextDeadline = (() => {
+              if (!task.deadline) return undefined;
+              const d = new Date(task.deadline);
+              switch (task.recurrence) {
+                case "daily":
+                  d.setDate(d.getDate() + 1);
+                  break;
+                case "weekly":
+                  d.setDate(d.getDate() + 7);
+                  break;
+                case "monthly":
+                  d.setMonth(d.getMonth() + 1);
+                  break;
+              }
+              return d;
+            })();
+            additionalTasks.push({
+              ...task,
+              id: generateUUID(),
+              done: false,
+              date: new Date(),
+              deadline: nextDeadline,
+              lastSave: undefined,
+            });
+          }
+          return { ...task, done: willBeDone, lastSave: new Date() };
         }
         return task;
       });
+      const finalTasks = [...updatedTasks, ...additionalTasks];
       setUser((prevUser) => ({
         ...prevUser,
-        tasks: updatedTasks,
+        tasks: finalTasks,
       }));
 
-      const allTasksDone = updatedTasks.every((task) => task.done);
+      const allTasksDone = finalTasks.every((task) => task.done);
 
       if (allTasksDone) {
         showToast(

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
 import { AddTaskRounded, CancelRounded } from "@mui/icons-material";
-import { IconButton, InputAdornment, Tooltip } from "@mui/material";
+import { IconButton, InputAdornment, Tooltip, MenuItem } from "@mui/material";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../constants";
 import { ColorPicker, TopBar, CustomEmojiPicker } from "../components";
 import { UserContext } from "../contexts/UserContext";
@@ -27,6 +27,7 @@ const AddTask = () => {
     "sessionStorage",
   );
   const [deadline, setDeadline] = useStorageState<string>("", "deadline", "sessionStorage");
+  const [recurrence, setRecurrence] = useStorageState<string>("", "recurrence", "sessionStorage");
   const [nameError, setNameError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
@@ -111,6 +112,7 @@ const AddTask = () => {
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
       category: selectedCategories ? selectedCategories : [],
+      recurrence: recurrence !== "" ? (recurrence as "daily" | "weekly" | "monthly") : undefined,
     };
 
     setUser((prevUser) => ({
@@ -129,7 +131,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -211,6 +221,18 @@ const AddTask = () => {
               },
             }}
           />
+
+          <StyledInput
+            label="Recurrence"
+            select
+            value={recurrence}
+            onChange={(e) => setRecurrence(e.target.value)}
+          >
+            <MenuItem value="">None</MenuItem>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </StyledInput>
 
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -50,6 +50,10 @@ export interface Task {
    */
   date: Date;
   deadline?: Date;
+  /**
+   * Recurrence frequency for repeating tasks
+   */
+  recurrence?: "daily" | "weekly" | "monthly";
   category?: Category[];
   lastSave?: Date;
   sharedBy?: string;


### PR DESCRIPTION
## Summary
- allow choosing daily, weekly, or monthly recurrence when adding/editing tasks
- generate next occurrence automatically when a recurring task is completed
- extend Task type with recurrence field

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a97b146aa4832b8f7e5de0eb2f6ab2