### PR TITLE
Add recurring task support

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -9,6 +9,7 @@ import {
   TextField,
   TextFieldProps,
   Tooltip,
+  MenuItem,
 } from "@mui/material";
 import { useContext, useEffect, useMemo, useState } from "react";
 import { ColorPicker, CustomDialogTitle, CustomEmojiPicker } from "..";
@@ -83,6 +84,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             emoji: editedTask.emoji || undefined,
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
+            recurrence: editedTask.recurrence || undefined,
             category: editedTask.category || undefined,
             lastSave: new Date(),
           };
@@ -241,6 +243,19 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
+
+        <StyledInput
+          label="Recurrence"
+          name="recurrence"
+          select
+          value={editedTask?.recurrence || ""}
+          onChange={handleInputChange}
+        >
+          <MenuItem value="">None</MenuItem>
+          <MenuItem value="daily">Daily</MenuItem>
+          <MenuItem value="weekly">Weekly</MenuItem>
+          <MenuItem value="monthly">Monthly</MenuItem>
+        </StyledInput>
 
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -70,12 +70,40 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
-      const updatedTasks = tasks.map((task) => {
+      let updatedTasks = tasks.map((task) => {
         if (task.id === selectedTaskId) {
           return { ...task, done: !task.done, lastSave: new Date() };
         }
         return task;
       });
+
+      const originalTask = tasks.find((t) => t.id === selectedTaskId);
+      if (originalTask && !originalTask.done && originalTask.recurrence) {
+        const newTask: Task = {
+          ...originalTask,
+          id: generateUUID(),
+          done: false,
+          date: new Date(),
+          lastSave: new Date(),
+        };
+        if (originalTask.deadline) {
+          const newDeadline = new Date(originalTask.deadline);
+          switch (originalTask.recurrence) {
+            case "daily":
+              newDeadline.setDate(newDeadline.getDate() + 1);
+              break;
+            case "weekly":
+              newDeadline.setDate(newDeadline.getDate() + 7);
+              break;
+            case "monthly":
+              newDeadline.setMonth(newDeadline.getMonth() + 1);
+              break;
+          }
+          newTask.deadline = newDeadline;
+        }
+        updatedTasks = [...updatedTasks, newTask];
+      }
+
       setUser((prevUser) => ({
         ...prevUser,
         tasks: updatedTasks,

--- a/src/components/tasks/TasksList.tsx
+++ b/src/components/tasks/TasksList.tsx
@@ -29,7 +29,7 @@ import { useStorageState } from "../../hooks/useStorageState";
 import { DialogBtn } from "../../styles";
 import { ColorPalette } from "../../theme/themeConfig";
 import type { Category, Task, UUID } from "../../types/user";
-import { getFontColor, showToast } from "../../utils";
+import { getFontColor, showToast, generateUUID } from "../../utils";
 import {
   NoTasks,
   RingAlarm,
@@ -267,16 +267,49 @@ export const TasksList: React.FC = () => {
   };
 
   const handleMarkSelectedAsDone = () => {
-    setUser((prevUser) => ({
-      ...prevUser,
-      tasks: prevUser.tasks.map((task) => {
+    setUser((prevUser) => {
+      const updatedTasks = prevUser.tasks.map((task) => {
         if (multipleSelectedTasks.includes(task.id)) {
           // Mark the task as done if selected
           return { ...task, done: true, lastSave: new Date() };
         }
         return task;
-      }),
-    }));
+      });
+
+      multipleSelectedTasks.forEach((taskId) => {
+        const originalTask = prevUser.tasks.find((t) => t.id === taskId);
+        if (originalTask && !originalTask.done && originalTask.recurrence) {
+          const newTask: Task = {
+            ...originalTask,
+            id: generateUUID(),
+            done: false,
+            date: new Date(),
+            lastSave: new Date(),
+          };
+          if (originalTask.deadline) {
+            const newDeadline = new Date(originalTask.deadline);
+            switch (originalTask.recurrence) {
+              case "daily":
+                newDeadline.setDate(newDeadline.getDate() + 1);
+                break;
+              case "weekly":
+                newDeadline.setDate(newDeadline.getDate() + 7);
+                break;
+              case "monthly":
+                newDeadline.setMonth(newDeadline.getMonth() + 1);
+                break;
+            }
+            newTask.deadline = newDeadline;
+          }
+          updatedTasks.push(newTask);
+        }
+      });
+
+      return {
+        ...prevUser,
+        tasks: updatedTasks,
+      };
+    });
     // Clear the selected task IDs after the operation
     setMultipleSelectedTasks([]);
   };

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
 import { AddTaskRounded, CancelRounded } from "@mui/icons-material";
-import { IconButton, InputAdornment, Tooltip } from "@mui/material";
+import { IconButton, InputAdornment, Tooltip, MenuItem } from "@mui/material";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../constants";
 import { ColorPicker, TopBar, CustomEmojiPicker } from "../components";
 import { UserContext } from "../contexts/UserContext";
@@ -27,6 +27,7 @@ const AddTask = () => {
     "sessionStorage",
   );
   const [deadline, setDeadline] = useStorageState<string>("", "deadline", "sessionStorage");
+  const [recurrence, setRecurrence] = useStorageState<string>("", "recurrence", "sessionStorage");
   const [nameError, setNameError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
@@ -110,6 +111,7 @@ const AddTask = () => {
       color,
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
+      recurrence: recurrence !== "" ? (recurrence as Task["recurrence"]) : undefined,
       category: selectedCategories ? selectedCategories : [],
     };
 
@@ -129,7 +131,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -211,6 +221,19 @@ const AddTask = () => {
               },
             }}
           />
+
+          <StyledInput
+            select
+            label="Recurrence"
+            value={recurrence}
+            onChange={(e) => setRecurrence(e.target.value)}
+            sx={{ width: "400px" }}
+          >
+            <MenuItem value="">None</MenuItem>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </StyledInput>
 
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -50,6 +50,7 @@ export interface Task {
    */
   date: Date;
   deadline?: Date;
+  recurrence?: "daily" | "weekly" | "monthly";
   category?: Category[];
   lastSave?: Date;
   sharedBy?: string;


### PR DESCRIPTION
## Summary
- allow choosing daily, weekly, or monthly recurrence when creating or editing tasks
- generate next occurrence when a recurring task is marked complete

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9fccbf9ac832bbbf626e669205222