### PR TITLE
feat: add recurring task support

### DIFF
--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -6,6 +6,7 @@ import {
   DialogContent,
   IconButton,
   InputAdornment,
+  MenuItem,
   TextField,
   TextFieldProps,
   Tooltip,
@@ -83,6 +84,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             emoji: editedTask.emoji || undefined,
             description: editedTask.description || undefined,
             deadline: editedTask.deadline || undefined,
+            recurrence: editedTask.recurrence || undefined,
             category: editedTask.category || undefined,
             lastSave: new Date(),
           };
@@ -241,6 +243,26 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
+
+        <StyledInput
+          label="Recurrence"
+          select
+          value={editedTask?.recurrence || "none"}
+          onChange={(e) =>
+            setEditedTask((prevTask) => ({
+              ...(prevTask as Task),
+              recurrence:
+                e.target.value === "none"
+                  ? undefined
+                  : (e.target.value as "daily" | "weekly" | "monthly"),
+            }))
+          }
+        >
+          <MenuItem value="none">None</MenuItem>
+          <MenuItem value="daily">Daily</MenuItem>
+          <MenuItem value="weekly">Weekly</MenuItem>
+          <MenuItem value="monthly">Monthly</MenuItem>
+        </StyledInput>
 
         {settings.enableCategories !== undefined && settings.enableCategories && (
           <CategorySelect

--- a/src/components/tasks/EditTask.tsx
+++ b/src/components/tasks/EditTask.tsx
@@ -243,7 +243,7 @@ export const EditTask = ({ open, task, onClose }: EditTaskProps) => {
             },
           }}
         />
-
+        {/* Dropdown for choosing how often the task should recur */}
         <StyledInput
           label="Recurrence"
           select

--- a/src/components/tasks/TaskMenu.tsx
+++ b/src/components/tasks/TaskMenu.tsx
@@ -70,18 +70,43 @@ export const TaskMenu = () => {
     // Toggles the "done" property of the selected task
     if (selectedTaskId) {
       handleCloseMoreMenu();
-      const updatedTasks = tasks.map((task) => {
-        if (task.id === selectedTaskId) {
-          return { ...task, done: !task.done, lastSave: new Date() };
-        }
-        return task;
-      });
-      setUser((prevUser) => ({
-        ...prevUser,
-        tasks: updatedTasks,
-      }));
+      let allTasksDone = false;
+      setUser((prevUser) => {
+        const targetTask = prevUser.tasks.find((t) => t.id === selectedTaskId);
+        let updatedTasks = prevUser.tasks.map((task) => {
+          if (task.id === selectedTaskId) {
+            return { ...task, done: !task.done, lastSave: new Date() };
+          }
+          return task;
+        });
 
-      const allTasksDone = updatedTasks.every((task) => task.done);
+        if (targetTask && !targetTask.done && targetTask.recurrence) {
+          const baseDate = targetTask.deadline ? new Date(targetTask.deadline) : new Date();
+          if (targetTask.recurrence === "daily") {
+            baseDate.setDate(baseDate.getDate() + 1);
+          } else if (targetTask.recurrence === "weekly") {
+            baseDate.setDate(baseDate.getDate() + 7);
+          } else if (targetTask.recurrence === "monthly") {
+            baseDate.setMonth(baseDate.getMonth() + 1);
+          }
+          const newTask: Task = {
+            ...targetTask,
+            id: generateUUID(),
+            done: false,
+            date: new Date(),
+            deadline: baseDate,
+            lastSave: new Date(),
+          };
+          updatedTasks = [...updatedTasks, newTask];
+        }
+
+        allTasksDone = updatedTasks.every((task) => task.done);
+
+        return {
+          ...prevUser,
+          tasks: updatedTasks,
+        };
+      });
 
       if (allTasksDone) {
         showToast(

--- a/src/pages/AddTask.tsx
+++ b/src/pages/AddTask.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { AddTaskButton, Container, StyledInput } from "../styles";
 import { AddTaskRounded, CancelRounded } from "@mui/icons-material";
-import { IconButton, InputAdornment, Tooltip } from "@mui/material";
+import { IconButton, InputAdornment, MenuItem, Tooltip } from "@mui/material";
 import { DESCRIPTION_MAX_LENGTH, TASK_NAME_MAX_LENGTH } from "../constants";
 import { ColorPicker, TopBar, CustomEmojiPicker } from "../components";
 import { UserContext } from "../contexts/UserContext";
@@ -27,6 +27,11 @@ const AddTask = () => {
     "sessionStorage",
   );
   const [deadline, setDeadline] = useStorageState<string>("", "deadline", "sessionStorage");
+  const [recurrence, setRecurrence] = useStorageState<string>(
+    "none",
+    "recurrence",
+    "sessionStorage",
+  );
   const [nameError, setNameError] = useState<string>("");
   const [descriptionError, setDescriptionError] = useState<string>("");
   const [selectedCategories, setSelectedCategories] = useStorageState<Category[]>(
@@ -110,6 +115,8 @@ const AddTask = () => {
       color,
       date: new Date(),
       deadline: deadline !== "" ? new Date(deadline) : undefined,
+      recurrence:
+        recurrence !== "none" ? (recurrence as "daily" | "weekly" | "monthly") : undefined,
       category: selectedCategories ? selectedCategories : [],
     };
 
@@ -129,7 +136,15 @@ const AddTask = () => {
       },
     );
 
-    const itemsToRemove = ["name", "color", "description", "emoji", "deadline", "categories"];
+    const itemsToRemove = [
+      "name",
+      "color",
+      "description",
+      "emoji",
+      "deadline",
+      "categories",
+      "recurrence",
+    ];
     itemsToRemove.map((item) => sessionStorage.removeItem(item));
   };
 
@@ -211,6 +226,19 @@ const AddTask = () => {
               },
             }}
           />
+
+          <StyledInput
+            label="Recurrence"
+            select
+            value={recurrence}
+            onChange={(e) => setRecurrence(e.target.value)}
+            sx={{ mb: 2 }}
+          >
+            <MenuItem value="none">None</MenuItem>
+            <MenuItem value="daily">Daily</MenuItem>
+            <MenuItem value="weekly">Weekly</MenuItem>
+            <MenuItem value="monthly">Monthly</MenuItem>
+          </StyledInput>
 
           {user.settings.enableCategories !== undefined && user.settings.enableCategories && (
             <div style={{ marginBottom: "14px" }}>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -50,6 +50,10 @@ export interface Task {
    */
   date: Date;
   deadline?: Date;
+  /**
+   * Recurrence interval for repeating tasks.
+   */
+  recurrence?: "daily" | "weekly" | "monthly";
   category?: Category[];
   lastSave?: Date;
   sharedBy?: string;


### PR DESCRIPTION
## Summary
- allow creating recurring tasks with daily, weekly, or monthly intervals
- let users edit recurrence in existing tasks and persist the setting
- when completing a recurring task, automatically schedule the next occurrence

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa00d6aea4832b841dc0e589ee8367