### PR TITLE
Parse new storage values before updating state

### DIFF
--- a/src/hooks/useStorageState.ts
+++ b/src/hooks/useStorageState.ts
@@ -36,7 +36,12 @@ export function useStorageState<T>(
   useEffect(() => {
     const handleStorageChange = (event: StorageEvent) => {
       if (event.key === key && event.newValue !== null && event.key !== "") {
-        setValue(event.newValue);
+        try {
+          setValue(JSON.parse(event.newValue));
+        } catch {
+          // If parsing fails, fallback to setting the raw value
+          setValue(event.newValue as unknown as T);
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
- parse storage events with `JSON.parse`
- fallback to raw value when parsing fails

## Testing
- `npm test` *(fails: timeAgo > should return "now" for recent dates)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0a3e81adc832baac92c7fb0fe0168